### PR TITLE
Bump flake, add tarpaulin to cargo

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -78,6 +78,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-unstable": {
+      "locked": {
+        "lastModified": 1651007983,
+        "narHash": "sha256-GNay7yDPtLcRcKCNHldug85AhAvBpTtPEJWSSDYBw8U=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "e10da1c7f542515b609f8dfbcf788f3d85b14936",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1637453606,
@@ -100,6 +116,7 @@
         "flake-utils": "flake-utils",
         "gitignoresrc": "gitignoresrc",
         "nixpkgs": "nixpkgs",
+        "nixpkgs-unstable": "nixpkgs-unstable",
         "rust-overlay": "rust-overlay"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -3,6 +3,7 @@
 
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-21.11";
+    nixpkgs-unstable.url = "github:NixOS/nixpkgs/nixos-unstable";
     rust-overlay.url = "github:oxalica/rust-overlay";
     flake-utils.url = "github:numtide/flake-utils";
     flake-compat = {
@@ -15,12 +16,19 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, flake-compat, gitignoresrc, rust-overlay, ... }@inputs:
+  outputs = { self, nixpkgs, flake-utils, rust-overlay, ... }@inputs:
     { } // (flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = import nixpkgs {
           inherit system;
-          overlays = [ (import rust-overlay) ];
+          overlays = [
+            (import rust-overlay)
+            (final: prev: {
+              cargo = final.pkgs.rust-bin.stable.latest.default;
+              rustc = final.pkgs.rust-bin.stable.latest.default;
+              inherit (import inputs.nixpkgs-unstable { inherit system; }) rust-analyzer-unwrapped rust-analyzer;
+            })
+          ];
         };
       in
       rec {


### PR DESCRIPTION
• Updated input 'flake-compat':
    'github:edolstra/flake-compat/b7547d3eed6f32d06102ead8991ec52ab0a4f1a7' (2022-01-03)
  → 'github:edolstra/flake-compat/b4a34015c698c7793d592d66adbab377907a2be8' (2022-04-19)
• Updated input 'flake-utils':
    'github:numtide/flake-utils/3cecb5b042f7f209c56ffd8371b2711a290ec797' (2022-02-07)
  → 'github:numtide/flake-utils/a4b154ebbdc88c8498a5c7b01589addc9e9cb678' (2022-04-11)
• Updated input 'gitignoresrc':
    'github:hercules-ci/gitignore.nix/5b9e0ff9d3b551234b4f3eb3983744fa354b17f1' (2021-10-25)
  → 'github:hercules-ci/gitignore.nix/bff2832ec341cf30acb3a4d3e2e7f1f7b590116a' (2022-03-05)
• Updated input 'nixpkgs':
    'github:NixOS/nixpkgs/b099eaa0e01a45fc3459bbe987c3405c425ef05c' (2022-03-01)
  → 'github:NixOS/nixpkgs/fd3e33d696b81e76b30160dfad2efb7ac1f19879' (2022-04-30)
• Updated input 'rust-overlay':
    'github:oxalica/rust-overlay/245c2712f502849041a1b1d0cc6a7588e94b2e3f' (2022-03-03)
  → 'github:oxalica/rust-overlay/979ae5a43bdb7662c9dfd2f57826afde0ad438bb' (2022-05-02)