### PR TITLE
Fix csv-reader to allow idiosyncratic escape

### DIFF
--- a/src/logical/table_manager.rs
+++ b/src/logical/table_manager.rs
@@ -565,7 +565,9 @@ impl TableManager {
 
                 let mut reader = ReaderBuilder::new()
                     .delimiter(b',')
+                    .escape(Some(b'\\'))
                     .has_headers(false)
+                    .double_quote(true)
                     .from_reader(File::open(file.as_path()).unwrap());
 
                 let col_table = read(&datatypes, &mut reader, dict).unwrap();


### PR DESCRIPTION
CSV reader now takes `\` as the idiosyncratic escape character, following the report in #105