### PR TITLE
Use generic Dictionary implementation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,8 @@ version = "0.1.0"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+[features]
+"no-prefixed-string-dictionary" = []
 
 [dependencies]
 env_logger = "*"

--- a/src/logical/execution/planning/plan_normal_head.rs
+++ b/src/logical/execution/planning/plan_normal_head.rs
@@ -12,6 +12,7 @@ use crate::{
     },
     physical::{
         datatypes::DataValueT,
+        dictionary::Dictionary,
         management::execution_plan::{ExecutionNodeRef, ExecutionResult, ExecutionTree},
         tabular::operations::triescan_append::AppendInstruction,
         util::Reordering,
@@ -21,14 +22,14 @@ use crate::{
 use super::plan_util::{join_binding, BODY_JOIN};
 
 /// Strategies for calculating the newly derived tables.
-pub trait HeadStrategy {
+pub trait HeadStrategy<Dict: Dictionary> {
     /// Do preperation work for the planning phase.
     fn initialize(rule: &Rule, analysis: &RuleAnalysis) -> Self;
 
     /// Calculate the concrete plan given a variable order.
     fn execution_tree(
         &self,
-        table_manager: &TableManager,
+        table_manager: &TableManager<Dict>,
         rule_info: &RuleInfo,
         variable_order: VariableOrder,
         step_number: usize,
@@ -115,7 +116,7 @@ impl DatalogStrategy {
     }
 }
 
-impl HeadStrategy for DatalogStrategy {
+impl<Dict: Dictionary> HeadStrategy<Dict> for DatalogStrategy {
     fn initialize(rule: &Rule, analysis: &RuleAnalysis) -> Self {
         let mut predicate_to_atoms = HashMap::<Identifier, Vec<HeadInstruction>>::new();
 
@@ -137,7 +138,7 @@ impl HeadStrategy for DatalogStrategy {
 
     fn execution_tree(
         &self,
-        table_manager: &TableManager,
+        table_manager: &TableManager<Dict>,
         _rule_info: &RuleInfo,
         variable_order: VariableOrder,
         step_number: usize,

--- a/src/logical/program_analysis/analysis.rs
+++ b/src/logical/program_analysis/analysis.rs
@@ -1,6 +1,9 @@
 use std::collections::HashSet;
 
-use crate::logical::model::{Atom, Identifier, Program, Rule, Term, Variable};
+use crate::{
+    logical::model::{Atom, Identifier, Program, Rule, Term, Variable},
+    physical::dictionary::Dictionary,
+};
 
 use super::variable_order::{build_preferable_variable_orders, VariableOrder};
 
@@ -75,7 +78,7 @@ pub struct ProgramAnalysis {
     pub derived_predicates: HashSet<Identifier>,
 }
 
-impl Program {
+impl<Dict: Dictionary> Program<Dict> {
     /// Collect all predicates that appear in a head atom into a [`HashSet`]
     fn get_head_predicates(&self) -> HashSet<Identifier> {
         let mut result = HashSet::<Identifier>::new();

--- a/src/logical/program_analysis/normalization.rs
+++ b/src/logical/program_analysis/normalization.rs
@@ -1,7 +1,8 @@
 use std::collections::HashSet;
 
-use crate::logical::model::{
-    Filter, FilterOperation, Identifier, Literal, Program, Rule, Term, Variable,
+use crate::{
+    logical::model::{Filter, FilterOperation, Identifier, Literal, Program, Rule, Term, Variable},
+    physical::dictionary::Dictionary,
 };
 
 // Transforms a given rule into a "normalized" form.
@@ -78,7 +79,7 @@ fn normalize_rule(rule: &mut Rule) {
     *rule.filters_mut() = new_filters;
 }
 
-impl Program {
+impl<Dict: Dictionary> Program<Dict> {
     /// Transforms the rules into a "normalized" form.
     pub fn normalize(&mut self) {
         self.rules_mut().iter_mut().for_each(normalize_rule);

--- a/src/logical/program_analysis/variable_order.rs
+++ b/src/logical/program_analysis/variable_order.rs
@@ -3,7 +3,7 @@
 // NOTE: some functions are slightly modified but the overall idea is reflected
 
 use crate::logical::Permutator;
-use crate::physical::dictionary::{Dictionary, PrefixedStringDictionary};
+use crate::physical::dictionary::Dictionary;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use super::super::{
@@ -50,7 +50,7 @@ impl VariableOrder {
     }
 
     /// Return [`String`] with the contents of this object for debugging.
-    pub fn debug(&self, dict: &PrefixedStringDictionary) -> String {
+    pub fn debug<Dict: Dictionary>(&self, dict: &Dict) -> String {
         let mut variable_vector = Vec::<Variable>::new();
         variable_vector.resize_with(self.0.len(), || Variable::Universal(Identifier(0)));
 
@@ -228,16 +228,16 @@ impl RuleVariableList for Vec<Variable> {
     }
 }
 
-struct VariableOrderBuilder<'a> {
-    program: &'a Program,
+struct VariableOrderBuilder<'a, Dict: Dictionary> {
+    program: &'a Program<Dict>,
     iteration_order_within_rule: IterationOrder,
     required_trie_column_orders: HashMap<Identifier, HashSet<ColumnOrder>>, // maps predicates to sets of column orders
     idb_preds: HashSet<Identifier>,
 }
 
-impl<'a> VariableOrderBuilder<'a> {
+impl<Dict: Dictionary> VariableOrderBuilder<'_, Dict> {
     fn build_for(
-        program: &Program,
+        program: &Program<Dict>,
         iteration_order_within_rule: IterationOrder,
         initial_column_orders: HashMap<Identifier, HashSet<ColumnOrder>>,
     ) -> Vec<VariableOrder> {
@@ -383,8 +383,8 @@ impl<'a> VariableOrderBuilder<'a> {
     }
 }
 
-pub(super) fn build_preferable_variable_orders(
-    program: &Program,
+pub(super) fn build_preferable_variable_orders<Dict: Dictionary>(
+    program: &Program<Dict>,
     initial_column_orders: Option<HashMap<Identifier, HashSet<ColumnOrder>>>,
 ) -> Vec<Vec<VariableOrder>> {
     let iteration_orders = [

--- a/src/meta/logging.rs
+++ b/src/meta/logging.rs
@@ -10,6 +10,7 @@ use crate::{
         program_analysis::analysis::RuleAnalysis,
     },
     physical::{
+        dictionary::Dictionary,
         management::{database::TableKeyType, execution_plan::ExecutionTree, ByteSized},
         tabular::{table_types::trie::Trie, traits::table::Table},
         util::Reordering,
@@ -17,7 +18,7 @@ use crate::{
 };
 
 /// Log: Rule application.
-pub fn log_apply_rule(_program: &Program, step: usize, rule_index: usize) {
+pub fn log_apply_rule<Dict: Dictionary>(_program: &Program<Dict>, step: usize, rule_index: usize) {
     // TOOO: Maybe add a to_string() method to rules so
     log::info!("<<< {step}: APPLYING RULE {rule_index} >>>");
 }
@@ -50,7 +51,10 @@ pub fn log_fragmentation_combine(predicate: Identifier, trie_opt: Option<&Trie>)
 }
 
 /// Log: Print all available variable orders.
-pub fn log_avaiable_variable_order(program: &Program, analysis: &RuleAnalysis) {
+pub fn log_avaiable_variable_order<Dict: Dictionary>(
+    program: &Program<Dict>,
+    analysis: &RuleAnalysis,
+) {
     log::info!("Available orders:");
     for (index, promising_order) in analysis.promising_variable_orders.iter().enumerate() {
         log::info!(

--- a/src/physical/dictionary.rs
+++ b/src/physical/dictionary.rs
@@ -1,6 +1,8 @@
 //! This module provides different dictionary functionalities
 //! In general these dictionary functionalities allow to represent [String] values as [usize] values
 
+use std::fmt::Debug;
+
 /// Module to define a [PrefixedStringDictionary]
 /// This will provide a more memory-efficient storage of [String] values if they share equivalent prefixes (such as IRIs)
 /// The prefixes of the [String] will be stored as a Triestructure.
@@ -11,7 +13,7 @@ pub mod string_dictionary;
 pub use string_dictionary::StringDictionary;
 
 /// This Dictionary Trait defines dictionaries, which keep ownership of the inserted elements.
-pub trait Dictionary {
+pub trait Dictionary: Debug + Default + Clone {
     /// Construct a new and empty [`Dictionary`]
     fn new() -> Self
     where

--- a/src/physical/dictionary/string_dictionary.rs
+++ b/src/physical/dictionary/string_dictionary.rs
@@ -3,7 +3,7 @@ use std::collections::HashMap;
 use std::rc::Rc;
 
 /// Offers a simple way to store multiple [String] objects, associate them to a [usize] and manage ownership for them
-#[derive(Debug, Default)]
+#[derive(Clone, Debug, Default)]
 pub struct StringDictionary {
     store: Vec<Rc<String>>,
     mapping: HashMap<Rc<String>, usize>,

--- a/src/physical/management/type_analysis.rs
+++ b/src/physical/management/type_analysis.rs
@@ -8,6 +8,7 @@ use crate::{
     error::Error,
     physical::{
         datatypes::DataTypeName,
+        dictionary::Dictionary,
         tabular::{
             operations::triescan_append::AppendInstruction,
             traits::table_schema::{TableSchema, TableSchemaEntry},
@@ -91,8 +92,8 @@ impl Display for TypeTree {
 
 impl TypeTree {
     /// Create a [`TypeTree`] from an [`ExecutionPlan`]
-    pub(super) fn from_execution_tree<TableKey: TableKeyType>(
-        instance: &DatabaseInstance<TableKey>,
+    pub(super) fn from_execution_tree<TableKey: TableKeyType, Dict: Dictionary>(
+        instance: &DatabaseInstance<TableKey, Dict>,
         temp_schemas: &HashMap<TableId, TableSchema>,
         tree: &ExecutionTree<TableKey>,
     ) -> Result<Self, Error> {
@@ -107,8 +108,8 @@ impl TypeTree {
     }
 
     /// Types are propagated from bottom to top through the [`ExecutionTree`].
-    fn propagate_up<TableKey: TableKeyType>(
-        instance: &DatabaseInstance<TableKey>,
+    fn propagate_up<TableKey: TableKeyType, Dict: Dictionary>(
+        instance: &DatabaseInstance<TableKey, Dict>,
         temp_schemas: &HashMap<TableId, TableSchema>,
         node: ExecutionNodeRef<TableKey>,
     ) -> Result<TypeTreeNode, Error> {
@@ -477,7 +478,7 @@ mod test {
 
     use crate::physical::{
         datatypes::{DataTypeName, DataValueT},
-        dictionary::PrefixedStringDictionary,
+        dictionary::StringDictionary,
         management::{
             database::TableId,
             execution_plan::{ExecutionResult, ExecutionTree},
@@ -748,8 +749,7 @@ mod test {
             schema_entry(DataTypeName::U32),
         ]);
 
-        let mut instance =
-            DatabaseInstance::<StringKeyType>::new(PrefixedStringDictionary::default());
+        let mut instance = DatabaseInstance::<StringKeyType, _>::new(StringDictionary::default());
         instance.add(String::from("TableA"), trie_a, schema_a);
         instance.add(String::from("TableB"), trie_b, schema_b);
         instance.add(String::from("TableC"), trie_c, schema_c);
@@ -784,8 +784,7 @@ mod test {
             schema_entry(DataTypeName::U32),
         ]);
 
-        let mut instance =
-            DatabaseInstance::<StringKeyType>::new(PrefixedStringDictionary::default());
+        let mut instance = DatabaseInstance::<StringKeyType, _>::new(StringDictionary::default());
         instance.add(String::from("TableA"), trie_a, schema_a);
         instance.add(String::from("TableB"), trie_b, schema_b);
 

--- a/src/physical/tabular/table_types/trie.rs
+++ b/src/physical/tabular/table_types/trie.rs
@@ -14,7 +14,7 @@ use crate::physical::columnar::{
     },
 };
 use crate::physical::datatypes::{data_value::VecT, DataTypeName, DataValueT};
-use crate::physical::dictionary::{Dictionary, PrefixedStringDictionary};
+use crate::physical::dictionary::Dictionary;
 use crate::physical::management::ByteSized;
 use crate::physical::tabular::traits::table_schema::TableColumnTypes;
 use crate::physical::tabular::traits::{table::Table, triescan::TrieScan};
@@ -60,7 +60,7 @@ impl Trie {
     }
 
     /// Return a [`DebugTrie`] from the [`Trie`]
-    pub fn debug<'a>(&'a self, dict: &'a PrefixedStringDictionary) -> DebugTrie<'a> {
+    pub fn debug<'a, Dict: Dictionary>(&'a self, dict: &'a Dict) -> DebugTrie<'a, Dict> {
         DebugTrie { trie: self, dict }
     }
 
@@ -76,10 +76,10 @@ impl Trie {
     }
 
     // TODO: unify this with Display Trait implementation
-    pub(crate) fn format_as_csv(
+    pub(crate) fn format_as_csv<Dict: Dictionary>(
         &self,
         f: &mut fmt::Formatter<'_>,
-        dict: &PrefixedStringDictionary,
+        dict: &Dict,
     ) -> fmt::Result {
         if self
             .columns
@@ -182,12 +182,12 @@ impl ByteSized for Trie {
 
 /// [`Trie`] which also contains an associated dictionary for displaying proper names
 #[derive(Debug)]
-pub struct DebugTrie<'a> {
+pub struct DebugTrie<'a, Dict: Dictionary> {
     trie: &'a Trie,
-    dict: &'a PrefixedStringDictionary,
+    dict: &'a Dict,
 }
 
-impl fmt::Display for DebugTrie<'_> {
+impl<Dict: Dictionary> fmt::Display for DebugTrie<'_, Dict> {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         self.trie.format_as_csv(f, self.dict)
     }


### PR DESCRIPTION
The old code was hard-coded to use the `PrefixedStringDictionary` in many places. This made testing with other `Dictionary` implementations quite cumbersome. To address this, everything is now generic in the `Dictionary` trait, und a feature
flag (`no-prefixed-string-dictionary`) is used to change the default for the CLI application from `PrefixedStringDictionary` to `StringDictionary`.