### PR TITLE
Align IRI representations in dictionaries with what we expect in CSV files

### DIFF
--- a/src/io/parser.rs
+++ b/src/io/parser.rs
@@ -756,7 +756,7 @@ mod test {
         let datatype = "bar";
         let p = parser.intern(predicate.to_owned());
         let v = parser.intern(value.to_owned()).0;
-        let t = parser.intern(datatype.to_owned()).0;
+        let t = parser.intern(format!("<{datatype}>")).0;
         let fact = format!(r#"{predicate}("{value}"^^<{datatype}>) ."#);
 
         assert_parse!(
@@ -782,7 +782,7 @@ mod test {
         let prefix_declaration = format!("@prefix {prefix}: <{iri}> .");
         let p = parser.intern(predicate.to_owned());
         let pn = format!("{prefix}:{name}");
-        let v = parser.intern(format!("{iri}{name}"));
+        let v = parser.intern(format!("<{iri}{name}>"));
         let fact = format!(r#"{predicate}({pn}) ."#);
 
         assert_parse!(parser.parse_prefix(), &prefix_declaration, prefix);
@@ -841,7 +841,7 @@ mod test {
         let predicate = "p";
         let name = "a";
         let p = parser.intern(predicate.to_owned());
-        let a = parser.intern(name.to_owned());
+        let a = parser.intern(format!("<{name}>"));
         let fact = format!(r#"{predicate}({name}) ."#);
 
         assert_parse!(
@@ -859,7 +859,7 @@ mod test {
         let datatype = "bar";
         let p = parser.intern(predicate.to_owned());
         let v = parser.intern(value.to_owned()).0;
-        let t = parser.intern(datatype.to_owned()).0;
+        let t = parser.intern(format!("<{datatype}>")).0;
         let fact = format!(
             r#"{predicate}(% comment 1
                  "{value}"^^<{datatype}> % comment 2


### PR DESCRIPTION
Try to parse String values in CSV files as IRIs, falling back to ordinary strings if it's not an IRIREF. This slows parsing down quite a bit, and still doesn't handle more complicated cases like typed RDF Literals. Needs (#116).

Also makes the LUBM extract fail, which is likely a different bug that is now triggered as some predicates are no longer empty.