### PR TITLE
Add reference after plan evaluation and change reference condition

### DIFF
--- a/src/logical/table_manager.rs
+++ b/src/logical/table_manager.rs
@@ -874,28 +874,60 @@ impl<Dict: Dictionary> TableManager<Dict> {
             tree.replace_temp_ids(&union_map);
         }
 
-        // Remove trees that only (project &) fetch another permanent table and replace it with a reference
+        // Remove trees that only (project &) fetch another permanent table and are themselves unused
+        // Remember them so they can still be added as references later
+        struct AddReference {
+            from_predicate: Identifier,
+            from_range: Range<usize>,
+            to: TableName,
+            reordering: Reordering,
+        }
+
+        let all_fetched_keys = plan.all_fetched_keys();
+        let mut references = Vec::<AddReference>::new();
+        let mut retain_index: usize = 0;
         plan.trees.retain(|t| {
-            if let ExecutionResult::Save(new_key) = t.result() {
+            let result = if let ExecutionResult::Save(new_key) = t.result() {
                 if let Some((ref_name, reordering)) = self.plan_recognize_renaming(t) {
-                    self.add_reference(
-                        new_key.name.predicate,
-                        self.translate_range(new_key.name.predicate, new_key.name.range),
-                        ref_name,
+                    if all_fetched_keys.contains(new_key) {
+                        return true;
+                    }
+
+                    references.push(AddReference {
+                        from_predicate: new_key.name.predicate,
+                        from_range: self
+                            .translate_range(new_key.name.predicate, new_key.name.range),
+                        to: ref_name,
                         reordering,
-                    );
+                    });
 
-                    result.insert(new_key.name.predicate);
-
-                    return false;
+                    false
+                } else {
+                    true
                 }
-            }
+            } else {
+                true
+            };
 
-            true
+            // Note: This works because retain guarantees the iteration order
+            retain_index += 1;
+
+            result
         });
 
         // Execute the omptimized plan
         result.extend(self.execute_plan(plan)?.iter());
+
+        // Add the references from before
+        for reference in references {
+            self.add_reference(
+                reference.from_predicate,
+                reference.from_range,
+                reference.to,
+                reference.reordering,
+            );
+        }
+
         Ok(result)
     }
 

--- a/src/physical/management/execution_plan.rs
+++ b/src/physical/management/execution_plan.rs
@@ -151,6 +151,21 @@ impl<TableKey: TableKeyType> ExecutionTree<TableKey> {
             .filter(|n| matches!(&*n.0.as_ref().borrow(), ExecutionNode::FetchTable(_)))
     }
 
+    /// Return all table keys that have been fetched
+    pub fn all_fetched_keys(&self) -> HashSet<TableKey> {
+        let mut result = HashSet::<TableKey>::new();
+
+        for node in &self.nodes {
+            let node_ref = &*node.0.as_ref().borrow();
+
+            if let ExecutionNode::FetchTable(key) = node_ref {
+                result.insert(key.clone());
+            }
+        }
+
+        result
+    }
+
     /// Push new node to list of all nodes and returns a reference.
     fn push_and_return_ref(&mut self, node: ExecutionNode<TableKey>) -> ExecutionNodeRef<TableKey> {
         self.nodes.push(ExecutionNodeOwned::new(node));
@@ -579,6 +594,19 @@ impl<TableKey: TableKeyType> ExecutionPlan<TableKey> {
         for tree in &mut self.trees {
             tree.replace_temp_ids(&renamed_temp);
         }
+    }
+
+    /// Return all table keys that have been fetched
+    pub fn all_fetched_keys(&self) -> HashSet<TableKey> {
+        let mut result = HashSet::<TableKey>::new();
+
+        for tree in &self.trees {
+            let tree_keys = tree.all_fetched_keys();
+
+            result = result.union(&tree_keys).cloned().collect();
+        }
+
+        result
     }
 }
 


### PR DESCRIPTION
Simple execution trees that would just copy another table are replaced with a table reference. There was a problem with adding the reference too early when the referenced table might still be computed. Also one should keep in mind that if you remove a table from the plan that no other table should depend on it.