### PR TITLE
Feature/149 tsv files

### DIFF
--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -18,12 +18,12 @@ use stage2::{
 
 fn load_trie(source: &DataSource, arity: usize, dict: &mut PrefixedStringDictionary) -> Trie {
     match source {
-        DataSource::CsvFile(file) => {
-            // Using fallback solution to treat eveything as string for now (storing as u64 internally)
+        DataSource::DsvFile { file, delimiter } => {
+            // Using fallback solution to treat everything as string for now (storing as u64 internally)
             let datatypes: Vec<Option<DataTypeName>> = (0..arity).map(|_| None).collect();
 
             let mut reader = ReaderBuilder::new()
-                .delimiter(b',')
+                .delimiter(*delimiter)
                 .has_headers(false)
                 .from_reader(File::open(file.as_path()).unwrap());
 

--- a/src/io/csv.rs
+++ b/src/io/csv.rs
@@ -14,12 +14,12 @@ use flate2::Compression;
 use sanitise_file_name::{sanitise_with_options, Options};
 
 /// Creates a [csv::Reader], based on any `Reader` which implements the [std::io::Read] trait
-pub(crate) fn reader<R>(rdr: R) -> Reader<R>
+pub(crate) fn reader<R>(rdr: R, delimiter: u8) -> Reader<R>
 where
     R: Read,
 {
     ReaderBuilder::new()
-        .delimiter(b',')
+        .delimiter(delimiter)
         .escape(Some(b'\\'))
         .has_headers(false)
         .double_quote(true)

--- a/src/io/parser.rs
+++ b/src/io/parser.rs
@@ -221,6 +221,14 @@ impl<'a> RuleParser<'a> {
                     ),
                     map(
                         delimited(
+                            preceded(tag("load-tsv"), self.parse_open_parenthesis()),
+                            turtle::string,
+                            self.parse_close_parenthesis(),
+                        ),
+                        DataSource::tsv_file,
+                    ),
+                    map(
+                        delimited(
                             preceded(tag("load-rdf"), self.parse_open_parenthesis()),
                             turtle::string,
                             self.parse_close_parenthesis(),

--- a/src/logical/execution/execution_engine.rs
+++ b/src/logical/execution/execution_engine.rs
@@ -94,7 +94,10 @@ impl ExecutionEngine {
         // Add all the data source declarations
         for ((predicate, _), source) in program.sources() {
             let new_source = match source {
-                DataSource::CsvFile(file) => TableSource::CSV(*file.clone()),
+                DataSource::DsvFile { file, delimiter } => TableSource::DSV {
+                    file: *file.clone(),
+                    delimiter: *delimiter,
+                },
                 DataSource::RdfFile(_) => todo!("RDF data sources are not yet implemented"),
                 DataSource::SparqlQuery(_) => {
                     todo!("SPARQL query data sources are not yet implemented")


### PR DESCRIPTION
Add support for tab-separated values files, while being general enough to easily support additional separators (`\0` might be interesting, since that should require much less escaping).

Based on top of #148, so should not be merged before ;)