### PR TITLE
fix unsoundness in columnscancell

### DIFF
--- a/src/physical/columnar/traits/columnscan.rs
+++ b/src/physical/columnar/traits/columnscan.rs
@@ -379,6 +379,9 @@ where
     }
 
     /// Forward `get_smallest_scans` to the underlying [`ColumnScanEnum`].
+    /// This takes an exclusive reference as opposed to an immutable one, so that none of the
+    /// mutating methods on &self can be called while the result is still available
+    /// (see https://github.com/knowsys/stage2/issues/137)
     pub fn get_smallest_scans(&mut self) -> &Vec<bool> {
         unsafe { &mut *self.0.get() }.get_smallest_scans()
     }


### PR DESCRIPTION
As described in the issue, keeping an immutable reference to the interior of a cell while mutating is UB. This is prevented by tying the lifetime of the shared reference to a mutable borrow of the cell, so none of the mutating methods on immutable reference can be called while holding the reference to the interior.