### PR TITLE
use Vec::fill instead of overwriting to prevent allocation

### DIFF
--- a/src/physical/columnar/operations/columnscan_union.rs
+++ b/src/physical/columnar/operations/columnscan_union.rs
@@ -103,7 +103,7 @@ where
     T: 'a + ColumnDataType,
 {
     fn seek(&mut self, value: T) -> Option<T> {
-        self.smallest_scans = vec![false; self.smallest_scans.len()];
+        self.smallest_scans.fill(false);
         let mut next_smallest: Option<T> = None;
 
         for &index in &self.active_scans {
@@ -137,7 +137,7 @@ where
     }
 
     fn reset(&mut self) {
-        self.smallest_scans = vec![true; self.smallest_scans.len()];
+        self.smallest_scans.fill(true);
         self.smallest_value = None;
     }
 

--- a/src/physical/tabular/operations/materialize.rs
+++ b/src/physical/tabular/operations/materialize.rs
@@ -104,7 +104,7 @@ pub fn materialize_inner(
                 current_row[current_layer] = false;
             }
         } else if is_last_layer && next_value.is_some() {
-            current_row = vec![true; arity - 1];
+            current_row.fill(true);
             is_empty = false;
 
             // At this point we know that the result will contain at least one variable


### PR DESCRIPTION
Just by chance I stumbled across allocation / deallocation going on in seek, when overwriting a vec. This is not a huge deal but also clearly undesirable. So here's some free micro seconds.