### PR TITLE
disable expensive sort check in ColumnScanRle::seek per default

### DIFF
--- a/src/physical/columnar/column_types/rle.rs
+++ b/src/physical/columnar/column_types/rle.rs
@@ -581,6 +581,7 @@ where
     /// If multiple candidates exist, the iterator should be advanced to the first such value.
     fn seek(&mut self, value: Self::Item) -> Option<Self::Item> {
         // seek only works correctly if column is sorted; we are just checking this here
+        #[cfg(check_column_sorting)]
         debug_assert!(
             self.column.is_empty()
                 || self


### PR DESCRIPTION
This ensures the performance in debug mode is sufficient to run non-trivial examples. The check can still be enabled by passing --cfg check_column_sorting