### PR TITLE
Feature/173 error rules

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -87,7 +87,7 @@ impl CliApp {
 
         self.prevent_accidential_overwrite(&app_state)?;
 
-        let mut exec_engine = ExecutionEngine::<StrategyRoundRobin>::initialize(app_state.program);
+        let mut exec_engine = ExecutionEngine::<StrategyRoundRobin>::initialize(app_state.program)?;
         TimedCode::instance().sub("Reading & Preprocessing").stop();
         TimedCode::instance().sub("Reasoning").start();
 
@@ -173,6 +173,8 @@ impl CliApp {
             acc
         });
         let program = all_input_consumed(parser.parse_program())(&input)?;
+        program.check_unsupported()?;
+
         log::info!("Rules parsed");
         log::trace!("{:?}", program);
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -40,6 +40,15 @@ pub enum Error {
     /// Error when converting floating type to integer point value
     #[error("Floating type could not be converted to integer value")]
     FloatingPointToInteger,
+    /// Conflicting type declarations
+    #[error("Conflicting type declarations. Predicate \"{0}\" at position {1} has been inferred to have the conflicting types {2} and {3}.")]
+    InvalidRuleConflictingTypes(String, usize, LogicalTypeEnum, LogicalTypeEnum),
+    /// Unsupported feature: Negation
+    #[error("Negation is currently unsupported.")]
+    UnsupportedFeatureNegation,
+    /// Unsupported feature: Negation
+    #[error("Comparison operations are currently not supported.")]
+    UnsupportedFeatureComparison,
     /// Parse errors
     #[error(transparent)]
     ParseError(#[from] ParseError),

--- a/src/io/parser/types.rs
+++ b/src/io/parser/types.rs
@@ -32,6 +32,14 @@ pub enum ParseError {
     /// A variable only occurs in negative literals in the rule body.
     #[error(r#"Variable "{0}" only occurs unsafely in negative literals in the rule body."#)]
     UnsafeNegatedVariable(String),
+    /// The universal variable does not occur in a positive body literal.
+    #[error(r#"The universal variable "{0}" does not occur in a positive body literal."#)]
+    UnsafeHeadVariable(String),
+    /// A variable used in a comparison does not occur in a positive body literal.
+    #[error(
+        r#"The variable "{0}" used in a comparison does not occur in a positive body literal."#
+    )]
+    UnsafeFilterVariable(String),
     /// A variable is both existentially and universally quantified
     #[error(r#"Variable "{0}" occurs with existential and universal quantification"#)]
     BothQuantifiers(String),

--- a/src/logical/execution/execution_engine.rs
+++ b/src/logical/execution/execution_engine.rs
@@ -58,10 +58,10 @@ pub struct ExecutionEngine<RuleSelectionStrategy> {
 
 impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
     /// Initialize [`ExecutionEngine`].
-    pub fn initialize(mut program: Program) -> Self {
+    pub fn initialize(mut program: Program) -> Result<Self, Error> {
         program.normalize();
 
-        let analysis = program.analyze();
+        let analysis = program.analyze()?;
 
         let mut table_manager = TableManager::new();
         Self::register_all_predicates(&mut table_manager, &analysis);
@@ -78,7 +78,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
             analysis.rule_analysis.iter().collect(),
         );
 
-        Self {
+        Ok(Self {
             program,
             analysis,
             rule_strategy,
@@ -87,7 +87,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
             predicate_last_union: HashMap::new(),
             rule_infos,
             current_step: 1,
-        }
+        })
     }
 
     fn register_all_predicates(table_manager: &mut TableManager, analysis: &ProgramAnalysis) {

--- a/src/logical/model.rs
+++ b/src/logical/model.rs
@@ -148,18 +148,14 @@ impl Atom {
 
     /// Return all universally quantified variables in the atom.
     pub fn universal_variables(&self) -> impl Iterator<Item = &Variable> + '_ {
-        self.variables().filter_map(|var| match var {
-            Variable::Universal(_) => Some(var),
-            _ => None,
-        })
+        self.variables()
+            .filter(|var| matches!(var, Variable::Universal(_)))
     }
 
     /// Return all existentially quantified variables in the atom.
     pub fn existential_variables(&self) -> impl Iterator<Item = &Variable> + '_ {
-        self.variables().filter_map(|var| match var {
-            Variable::Existential(_) => Some(var),
-            _ => None,
-        })
+        self.variables()
+            .filter(|var| matches!(var, Variable::Existential(_)))
     }
 }
 

--- a/src/logical/model.rs
+++ b/src/logical/model.rs
@@ -43,6 +43,15 @@ pub enum Variable {
     Existential(Identifier),
 }
 
+impl Variable {
+    /// Return the name of the variable.
+    pub fn name(&self) -> String {
+        match self {
+            Self::Universal(identifier) | Self::Existential(identifier) => identifier.name(),
+        }
+    }
+}
+
 /// Terms occurring in programs.
 #[derive(Debug, Eq, PartialEq, Clone, PartialOrd, Ord)]
 pub enum Term {
@@ -138,17 +147,17 @@ impl Atom {
     }
 
     /// Return all universally quantified variables in the atom.
-    pub fn universal_variables(&self) -> impl Iterator<Item = &Identifier> + '_ {
+    pub fn universal_variables(&self) -> impl Iterator<Item = &Variable> + '_ {
         self.variables().filter_map(|var| match var {
-            Variable::Universal(identifier) => Some(identifier),
+            Variable::Universal(_) => Some(var),
             _ => None,
         })
     }
 
     /// Return all existentially quantified variables in the atom.
-    pub fn existential_variables(&self) -> impl Iterator<Item = &Identifier> + '_ {
+    pub fn existential_variables(&self) -> impl Iterator<Item = &Variable> + '_ {
         self.variables().filter_map(|var| match var {
-            Variable::Existential(identifier) => Some(identifier),
+            Variable::Existential(_) => Some(var),
             _ => None,
         })
     }
@@ -215,12 +224,12 @@ impl Literal {
     }
 
     /// Return the universally quantified variables in the literal.
-    pub fn universal_variables(&self) -> impl Iterator<Item = &Identifier> + '_ {
+    pub fn universal_variables(&self) -> impl Iterator<Item = &Variable> + '_ {
         forward_to_atom!(self, universal_variables)
     }
 
     /// Return the existentially quantified variables in the literal.
-    pub fn existential_variables(&self) -> impl Iterator<Item = &Identifier> + '_ {
+    pub fn existential_variables(&self) -> impl Iterator<Item = &Variable> + '_ {
         forward_to_atom!(self, existential_variables)
     }
 }
@@ -331,11 +340,11 @@ impl Rule {
         }
 
         // Check if a variable occurs with both existential and universal quantification.
-        let mut universal_variables = body
+        let universal_variables = body
             .iter()
             .flat_map(|literal| literal.universal_variables())
             .collect::<HashSet<_>>();
-        universal_variables.extend(head.iter().flat_map(|atom| atom.universal_variables()));
+
         let existential_variables = head
             .iter()
             .flat_map(|atom| atom.existential_variables())
@@ -350,6 +359,42 @@ impl Rule {
             return Err(ParseError::BothQuantifiers(
                 common_variables.first().expect("is not empty here").name(),
             ));
+        }
+
+        // Check if there are universal variables in the head which do not occur in a positive body literal
+        let head_universal_variables = head
+            .iter()
+            .flat_map(|atom| atom.universal_variables())
+            .collect::<HashSet<_>>();
+
+        for head_variable in head_universal_variables {
+            if !universal_variables.contains(head_variable) {
+                return Err(ParseError::UnsafeHeadVariable(head_variable.name()));
+            }
+        }
+
+        // Check if filters are correctly formed
+        for filter in &filters {
+            let mut filter_variables = vec![&filter.left];
+
+            if let Term::Variable(right_variable) = &filter.right {
+                filter_variables.push(right_variable);
+            }
+
+            for variable in filter_variables {
+                match variable {
+                    Variable::Universal(universal_variable) => {
+                        if !positive_varibales.contains(variable) {
+                            return Err(ParseError::UnsafeFilterVariable(
+                                universal_variable.name(),
+                            ));
+                        }
+                    }
+                    Variable::Existential(existential_variable) => {
+                        return Err(ParseError::BodyExistential(existential_variable.name()))
+                    }
+                }
+            }
         }
 
         Ok(Rule {

--- a/src/logical/program_analysis/analysis.rs
+++ b/src/logical/program_analysis/analysis.rs
@@ -360,7 +360,7 @@ impl Program {
 
                 if let Term::Variable(variable_right) = &filter.right {
                     let position_right = variable_to_last_node
-                        .get(&variable_right)
+                        .get(variable_right)
                         .expect("Variables in filters should also appear in the rule body")
                         .clone();
 
@@ -422,7 +422,7 @@ impl Program {
                                 return Err(Error::InvalidRuleConflictingTypes(
                                     next_position.predicate.0.clone(),
                                     next_position.position + 1,
-                                    current_type.clone(),
+                                    *current_type,
                                     logical_type,
                                 ));
                             }


### PR DESCRIPTION
Throws error messages on:

- Unsafe head variables
- Unsafe filter variables, existential filter variables (maybe we should disallow the filter syntax altogether, though I wouldn't mind ?X = C and ?X = ?Y staying) 
- Inconsistent type declarations

Closes #173.
Closes #140.