### PR TITLE
Feature/198 output

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ sanitise-file-name = "1.0.0"
 flate2 = "1.0.25"
 rand = "0.8.4"
 petgraph = "0.6.3"
+colored = "2"
 
 [dev-dependencies]
 test-log = "0.2"

--- a/src/logical/execution/execution_engine.rs
+++ b/src/logical/execution/execution_engine.rs
@@ -257,6 +257,19 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
         Ok(result_ids)
     }
 
+    /// Count the number of derived facts during the computation.
+    pub fn count_derived_facts(&self) -> usize {
+        let mut result = 0;
+
+        for predicate in &self.analysis.derived_predicates {
+            if let Some(count) = self.table_manager.predicate_count_rows(predicate) {
+                result += count;
+            }
+        }
+
+        result
+    }
+
     /// Returns a reference to the Trie corresponding to the table_id
     pub fn write_predicate_to_disk(
         &self,

--- a/src/logical/table_manager.rs
+++ b/src/logical/table_manager.rs
@@ -104,6 +104,16 @@ impl SubtableHandler {
         Some(self.single[postion].1)
     }
 
+    pub fn count_rows(&self, database: &DatabaseInstance) -> usize {
+        let mut result = 0;
+
+        for (_, subtable_id) in &self.single {
+            result += database.count_rows(subtable_id);
+        }
+
+        result
+    }
+
     pub fn add_single_table(&mut self, step: usize, id: TableId) {
         debug_assert!(self.single.is_empty() || (self.single.last().unwrap().0 < step));
         self.single.push((step, id));
@@ -298,6 +308,13 @@ impl TableManager {
     /// Returns `None` if the predicate has no subtables.
     pub fn last_step(&self, predicate: Identifier) -> Option<usize> {
         self.predicate_subtables.get(&predicate)?.last_step()
+    }
+
+    /// Count all the rows that belong to a predicate.
+    pub fn predicate_count_rows(&self, predicate: &Identifier) -> Option<usize> {
+        self.predicate_subtables
+            .get(predicate)
+            .map(|s| s.count_rows(&self.database))
     }
 
     /// Write the Trie associated with the given id to CSV.

--- a/src/main.rs
+++ b/src/main.rs
@@ -21,27 +21,12 @@
 pub mod app;
 
 use clap::Parser;
-
-use nemo::meta::timing::TimedDisplay;
-use nemo::meta::TimedCode;
+use colored::Colorize;
 
 fn main() {
-    TimedCode::instance().start();
     let mut app = app::CliApp::parse();
     if let Err(err) = app.run() {
-        eprintln!("Application Error: {err}");
+        eprintln!("{} {err}", "Application Error:".red().bold());
         std::process::exit(1);
     }
-    TimedCode::instance().stop();
-    println!(
-        "\n{}",
-        TimedCode::instance().create_tree_string(
-            "nemo",
-            &[
-                TimedDisplay::default(),
-                TimedDisplay::default(),
-                TimedDisplay::new(nemo::meta::timing::TimedSorting::LongestThreadTime, 0)
-            ]
-        )
-    );
 }

--- a/src/meta/timing.rs
+++ b/src/meta/timing.rs
@@ -138,6 +138,11 @@ impl TimedCode {
         current_block
     }
 
+    /// Return the total system time this block took.
+    pub fn total_system_time(&self) -> Duration {
+        self.info.total_system_time
+    }
+
     /// Start the next measurement
     pub fn start(&mut self) {
         if cfg!(test) {

--- a/src/physical/management/database.rs
+++ b/src/physical/management/database.rs
@@ -364,6 +364,21 @@ impl OrderedReferenceManager {
         self.map.remove(id)?;
         Some(())
     }
+
+    /// Return the number of rows contained in this table.
+    pub fn count_rows(&self, id: &TableId) -> usize {
+        if let Some(resolved) = self.resolve_reference(*id, &ColumnOrder::default()) {
+            if let Some((_, storage)) = resolved.map.iter().next() {
+                // TODO: Technically we should be able to somehow count non-inmemory tables
+                // But this is not relevant for now
+                if let TableStorage::InMemory(trie) = storage {
+                    return trie.row_num();
+                }
+            }
+        }
+
+        return 0;
+    }
 }
 
 impl ByteSized for OrderedReferenceManager {
@@ -444,6 +459,11 @@ impl DatabaseInstance {
             current_null,
             current_id: TableId::default(),
         }
+    }
+
+    /// Return the number of rows for a given table.
+    pub fn count_rows(&self, table_id: &TableId) -> usize {
+        self.storage_handler.count_rows(table_id)
     }
 
     /// Return the current number of tables.

--- a/src/physical/management/database.rs
+++ b/src/physical/management/database.rs
@@ -368,16 +368,14 @@ impl OrderedReferenceManager {
     /// Return the number of rows contained in this table.
     pub fn count_rows(&self, id: &TableId) -> usize {
         if let Some(resolved) = self.resolve_reference(*id, &ColumnOrder::default()) {
-            if let Some((_, storage)) = resolved.map.iter().next() {
-                // TODO: Technically we should be able to somehow count non-inmemory tables
-                // But this is not relevant for now
-                if let TableStorage::InMemory(trie) = storage {
-                    return trie.row_num();
-                }
+            // TODO: Technically we should be able to somehow count non-inmemory tables
+            // But this is not relevant for now
+            if let Some((_, TableStorage::InMemory(trie))) = resolved.map.iter().next() {
+                return trie.row_num();
             }
         }
 
-        return 0;
+        0
     }
 }
 


### PR DESCRIPTION
When finishing computation the big ascii table is no longer shown by default (but can be enabled with the option `--detailed-timing`). Instead the output looks like this:

```
Reasoning completed in 4569ms. Derived 1906906 facts.
   Loading input:   177ms
   Reasoning:      3404ms
   Saving output:   987ms
```