### PR TITLE
Check constants for type consistency

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,7 +1,8 @@
 //! Error-handling module for the crate
 
 use crate::{
-    io::parser::ParseError, logical::types::LogicalTypeEnum,
+    io::parser::ParseError,
+    logical::{model::Term, types::LogicalTypeEnum},
     physical::datatypes::float_is_nan::FloatIsNaN,
 };
 use thiserror::Error;
@@ -43,6 +44,9 @@ pub enum Error {
     /// Conflicting type declarations
     #[error("Conflicting type declarations. Predicate \"{0}\" at position {1} has been inferred to have the conflicting types {2} and {3}.")]
     InvalidRuleConflictingTypes(String, usize, LogicalTypeEnum, LogicalTypeEnum),
+    /// Conflicting type declarations
+    #[error("Conflicting type declarations. The term \"{0}\" cannot be converted to a {1}.")]
+    InvalidRuleTermConversion(Term, LogicalTypeEnum),
     /// Unsupported feature: Negation
     #[error("Negation is currently unsupported.")]
     UnsupportedFeatureNegation,

--- a/src/logical/execution/execution_engine.rs
+++ b/src/logical/execution/execution_engine.rs
@@ -143,7 +143,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                 // TODO: get rid of unwrap
                 .map(|(i, t)| {
                     analysis.predicate_types.get(&fact.0.predicate()).unwrap()[i]
-                        .ground_term_to_data_value_t(t.clone())
+                        .ground_term_to_data_value_t(t.clone()).expect("Trying to convert a ground type into an invalid logical type. Should have been prevented by the type checker.")
                 })
                 .collect();
 

--- a/src/logical/execution/planning/plan_util.rs
+++ b/src/logical/execution/planning/plan_util.rs
@@ -115,7 +115,7 @@ pub(super) fn compute_filters(
                     value: variable_types
                         .get(&filter.left)
                         .unwrap()
-                        .ground_term_to_data_value_t(filter.right.clone()),
+                        .ground_term_to_data_value_t(filter.right.clone()).expect("Trying to convert a ground type into an invalid logical type. Should have been prevented by the type checker."),
                 });
             }
         }
@@ -204,7 +204,7 @@ pub(super) fn head_instruction_from_atom(atom: &Atom, analysis: &RuleAnalysis) -
                 current_append_vector = append_instructions.last_mut().unwrap();
             }
         } else {
-            let data_value_t = logical_type.ground_term_to_data_value_t(term.clone());
+            let data_value_t = logical_type.ground_term_to_data_value_t(term.clone()).expect("Trying to convert a ground type into an invalid logical type. Should have been prevented by the type checker.");
             let instruction = AppendInstruction::Constant(data_value_t);
             current_append_vector.push(instruction);
         }

--- a/src/logical/model.rs
+++ b/src/logical/model.rs
@@ -2,6 +2,7 @@
 
 use std::{
     collections::{HashMap, HashSet},
+    fmt::Debug,
     ops::Neg,
     path::{Path, PathBuf},
 };
@@ -34,6 +35,12 @@ impl Identifier {
     }
 }
 
+impl std::fmt::Display for Identifier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.name(), f)
+    }
+}
+
 /// Variable occuring in a rule
 #[derive(Debug, Eq, PartialEq, Hash, Clone, PartialOrd, Ord)]
 pub enum Variable {
@@ -52,6 +59,12 @@ impl Variable {
     }
 }
 
+impl std::fmt::Display for Variable {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        std::fmt::Display::fmt(&self.name(), f)
+    }
+}
+
 /// Terms occurring in programs.
 #[derive(Debug, Eq, PartialEq, Clone, PartialOrd, Ord)]
 pub enum Term {
@@ -63,6 +76,17 @@ pub enum Term {
     NumericLiteral(NumericLiteral),
     /// An RDF literal.
     RdfLiteral(RdfLiteral),
+}
+
+impl std::fmt::Display for Term {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match &self {
+            Term::Constant(term) => std::fmt::Display::fmt(term, f),
+            Term::Variable(term) => std::fmt::Display::fmt(term, f),
+            Term::NumericLiteral(term) => std::fmt::Display::fmt(term, f),
+            Term::RdfLiteral(term) => std::fmt::Display::fmt(term, f),
+        }
+    }
 }
 
 impl Term {
@@ -86,6 +110,16 @@ pub enum NumericLiteral {
     Double(Double),
 }
 
+impl std::fmt::Display for NumericLiteral {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NumericLiteral::Integer(value) => write!(f, "{value}"),
+            NumericLiteral::Decimal(left, right) => write!(f, "{left}.{right}"),
+            NumericLiteral::Double(value) => write!(f, "{value}"),
+        }
+    }
+}
+
 /// An RDF literal.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, PartialOrd, Ord)]
 pub enum RdfLiteral {
@@ -103,6 +137,15 @@ pub enum RdfLiteral {
         /// The datatype IRI.
         datatype: String,
     },
+}
+
+impl std::fmt::Display for RdfLiteral {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RdfLiteral::LanguageString { value, tag } => write!(f, "\"{value}\"@{tag}"),
+            RdfLiteral::DatatypeValue { value, datatype } => write!(f, "\"{value}\"^^{datatype}"),
+        }
+    }
 }
 
 /// An atom.
@@ -683,7 +726,7 @@ impl DataSource {
     }
 }
 
-impl std::fmt::Debug for DataSource {
+impl Debug for DataSource {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Self::DsvFile {

--- a/src/logical/program_analysis/analysis.rs
+++ b/src/logical/program_analysis/analysis.rs
@@ -377,11 +377,19 @@ impl Program {
         position_graph: &PositionGraph,
         all_predicates: &HashSet<(Identifier, usize)>,
     ) -> Result<HashMap<Identifier, Vec<LogicalTypeEnum>>, Error> {
-        // Set all predicate types to unknown
-        let mut predicate_types: HashMap<Identifier, Vec<Option<LogicalTypeEnum>>> = all_predicates
-            .iter()
-            .map(|(predicate, arity)| (predicate.clone(), vec![None; *arity]))
+        // Initialize predicate types with the user provided values
+        let mut predicate_types: HashMap<Identifier, Vec<Option<LogicalTypeEnum>>> = self
+            .parsed_predicate_declarations()
+            .into_iter()
+            .map(|(predicate, types)| (predicate, types.into_iter().map(Some).collect()))
             .collect();
+
+        // Set all predicates that did not receive explicit type information to `None` which represents unknown.
+        for (predicate, arity) in all_predicates {
+            if let Entry::Vacant(entry) = predicate_types.entry(predicate.clone()) {
+                entry.insert(vec![None; *arity]);
+            }
+        }
 
         // If there is an existential variable at some potion,
         // it will be assigned to the type `LogicalTypeEnum::RdfsResource`
@@ -467,6 +475,60 @@ impl Program {
         Ok(())
     }
 
+    // Check if there is a constant that cannot be converted into the type of
+    // the variable/predicate position it is compared to.
+    fn check_type_conflict_constants(
+        &self,
+        analyses: &[RuleAnalysis],
+        predicate_types: &HashMap<Identifier, Vec<LogicalTypeEnum>>,
+    ) -> Result<(), Error> {
+        for fact in self.facts() {
+            let predicate_types = predicate_types
+                .get(&fact.0.predicate())
+                .expect("Previous analysis should have assigned a type vector to each predicate.");
+
+            for (term_index, ground_term) in fact.0.terms().iter().enumerate() {
+                let logical_type = predicate_types[term_index];
+                logical_type.ground_term_to_data_value_t(ground_term.clone())?;
+            }
+        }
+
+        for (rule, analysis) in self.rules().iter().zip(analyses.iter()) {
+            for filter in rule.filters() {
+                let left_variable = &filter.left;
+                let right_term = if let Term::Variable(_) = filter.right {
+                    continue;
+                } else {
+                    &filter.right
+                };
+
+                let variable_type = analysis
+                    .variable_types
+                    .get(left_variable)
+                    .expect("Previous analysis should have assigned a type to each variable.");
+
+                variable_type.ground_term_to_data_value_t(right_term.clone())?;
+            }
+
+            for atom in rule.head() {
+                let predicate_types = predicate_types.get(&atom.predicate()).expect(
+                    "Previous analysis should have assigned a type vector to each predicate.",
+                );
+
+                for (term_index, term) in atom.terms().iter().enumerate() {
+                    if let Term::Variable(_) = term {
+                        continue;
+                    }
+
+                    let logical_type = predicate_types[term_index];
+                    logical_type.ground_term_to_data_value_t(term.clone())?;
+                }
+            }
+        }
+
+        Ok(())
+    }
+
     /// Analyze itself and return a struct containing the results.
     pub fn analyze(&self) -> Result<ProgramAnalysis, Error> {
         let BuilderResultVariants {
@@ -494,6 +556,8 @@ impl Program {
                 )
             })
             .collect();
+
+        self.check_type_conflict_constants(&rule_analysis, &predicate_types)?;
 
         Ok(ProgramAnalysis {
             rule_analysis,


### PR DESCRIPTION
Checks whether a `Term` appearing in fact or rule can be converted into the needed logical type, and outputs a user error if this is not the case.

Also fixes a bug where the logical types would not be correctly initialized with the user provided types.

Closes #196.