### PR TITLE
Clean up `TrieScan` invariant checking

### DIFF
--- a/src/physical/tabular/operations/triescan_join.rs
+++ b/src/physical/tabular/operations/triescan_join.rs
@@ -274,8 +274,9 @@ impl<'a> TrieScanJoin<'a> {
 
 impl<'a> TrieScan<'a> for TrieScanJoin<'a> {
     fn up(&mut self) {
-        debug_assert!(self.current_layer.is_some());
-        let current_layer = self.current_layer.unwrap();
+        let current_layer = self
+            .current_layer
+            .expect("calling up only allowed after calling down");
         let current_scans = &self.layers_to_scans[current_layer];
 
         for &scan_index in current_scans {
@@ -307,8 +308,6 @@ impl<'a> TrieScan<'a> for TrieScanJoin<'a> {
     }
 
     fn current_scan(&mut self) -> Option<&mut ColumnScanT<'a>> {
-        debug_assert!(self.current_layer.is_some());
-
         Some(self.merge_joins[self.current_layer?].get_mut())
     }
 

--- a/src/physical/tabular/operations/triescan_minus.rs
+++ b/src/physical/tabular/operations/triescan_minus.rs
@@ -105,13 +105,10 @@ impl<'a> TrieScanMinus<'a> {
 
 impl<'a> TrieScan<'a> for TrieScanMinus<'a> {
     fn up(&mut self) {
-        debug_assert!(self.layer_left.is_some());
-
-        self.layer_left = if self.layer_left.unwrap() == 0 {
-            None
-        } else {
-            Some(self.layer_left.unwrap() - 1)
-        };
+        self.layer_left = self
+            .layer_left
+            .expect("calling up only allowed after calling down")
+            .checked_sub(1);
 
         self.trie_left.up();
 

--- a/src/physical/tabular/operations/triescan_project.rs
+++ b/src/physical/tabular/operations/triescan_project.rs
@@ -132,8 +132,9 @@ impl<'a> TrieScanProject<'a> {
 
 impl<'a> TrieScan<'a> for TrieScanProject<'a> {
     fn up(&mut self) {
-        debug_assert!(self.current_layer.is_some());
-        let current_layer = self.current_layer.unwrap();
+        let current_layer = self
+            .current_layer
+            .expect("calling up only allowed after calling down");
 
         self.current_layer = if current_layer == 0 {
             None
@@ -267,8 +268,6 @@ impl<'a> TrieScan<'a> for TrieScanProject<'a> {
     }
 
     fn current_scan(&mut self) -> Option<&mut ColumnScanT<'a>> {
-        debug_assert!(self.current_layer.is_some());
-
         Some(self.reorder_scans[self.current_layer?].get_mut())
     }
 

--- a/src/physical/tabular/operations/triescan_select.rs
+++ b/src/physical/tabular/operations/triescan_select.rs
@@ -129,9 +129,10 @@ impl<'a> TrieScanSelectEqual<'a> {
 
 impl<'a> TrieScan<'a> for TrieScanSelectEqual<'a> {
     fn up(&mut self) {
-        debug_assert!(self.current_layer.is_some());
-
-        self.current_layer = self.current_layer.unwrap().checked_sub(1);
+        self.current_layer = self
+            .current_layer
+            .expect("calling up only allowed after calling down")
+            .checked_sub(1);
 
         self.base_trie.up();
     }
@@ -298,10 +299,10 @@ impl<'a> TrieScanSelectValue<'a> {
 
 impl<'a> TrieScan<'a> for TrieScanSelectValue<'a> {
     fn up(&mut self) {
-        debug_assert!(self.current_layer.is_some());
-
-        self.current_layer = self.current_layer.unwrap().checked_sub(1);
-
+        self.current_layer = self
+            .current_layer
+            .expect("calling up only allowed after calling down")
+            .checked_sub(1);
         self.base_trie.up();
     }
 

--- a/src/physical/tabular/operations/triescan_union.rs
+++ b/src/physical/tabular/operations/triescan_union.rs
@@ -87,12 +87,10 @@ impl<'a> TrieScanUnion<'a> {
 
 impl<'a> TrieScan<'a> for TrieScanUnion<'a> {
     fn up(&mut self) {
-        debug_assert!(self.current_layer.is_some());
-        let up_layer = if self.current_layer.unwrap() == 0 {
-            None
-        } else {
-            Some(self.current_layer.unwrap() - 1)
-        };
+        let up_layer = self
+            .current_layer
+            .expect("calling up only allowed after calling down")
+            .checked_sub(1);
 
         for scan_index in 0..self.layers.len() {
             if self.layers[scan_index] == self.current_layer {


### PR DESCRIPTION
Currently the `TrieScan` interface functions are pretty inconsistent in checking their invariants. For example we would want to use `expect` instead of `debug_assert` + `unwrap`. But not every implementation supports the same invariants. So what should be allowed and what should cause a panic still needs to be determined.