### PR TITLE
Combine efficiency

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -877,8 +877,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c85e1d9ab2eadba7e5040d4e09cbd6d072b76a557ad64e797c2cb9d4da21d7e4"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1340,6 +1342,7 @@ dependencies = [
  "dir-test",
  "env_logger 0.10.0",
  "flate2",
+ "getrandom",
  "howlong",
  "iai",
  "linked-hash-map",

--- a/benches/operations.rs
+++ b/benches/operations.rs
@@ -15,10 +15,10 @@ use nemo::{
         tabular::{
             operations::{
                 materialize, triescan_project::ProjectReordering, JoinBindings, TrieScanJoin,
-                TrieScanProject, TrieScanUnion,
+                TrieScanProject, TrieScanPrune, TrieScanUnion,
             },
             table_types::trie::{Trie, TrieScanGeneric},
-            traits::{table::Table, table_schema::TableSchema, triescan::TrieScanEnum},
+            traits::{partial_trie_scan::TrieScanEnum, table::Table, table_schema::TableSchema},
         },
     },
 };
@@ -105,7 +105,9 @@ pub fn benchmark_join(c: &mut Criterion) {
                 )
             },
             |join_iter| {
-                let _ = materialize(&mut TrieScanEnum::TrieScanJoin(join_iter));
+                let _ = materialize(&mut TrieScanPrune::new(TrieScanEnum::TrieScanJoin(
+                    join_iter,
+                )));
             },
         );
     });
@@ -186,7 +188,10 @@ fn benchmark_project(c: &mut Criterion) {
         &JoinBindings::new(vec![vec![0, 1, 2], vec![0, 1, 3]]),
     );
 
-    let join_trie = materialize(&mut TrieScanEnum::TrieScanJoin(join_iter)).unwrap();
+    let join_trie = materialize(&mut TrieScanPrune::new(TrieScanEnum::TrieScanJoin(
+        join_iter,
+    )))
+    .unwrap();
 
     let mut group_ours = c.benchmark_group("trie_project");
     group_ours.sample_size(10);
@@ -194,7 +199,9 @@ fn benchmark_project(c: &mut Criterion) {
         b.iter_with_setup(
             || TrieScanProject::new(&join_trie, ProjectReordering::from_vector(vec![0, 3], 4)),
             |project_iter| {
-                let _ = materialize(&mut TrieScanEnum::TrieScanProject(project_iter));
+                let _ = materialize(&mut TrieScanPrune::new(TrieScanEnum::TrieScanProject(
+                    project_iter,
+                )));
             },
         );
     });
@@ -202,7 +209,9 @@ fn benchmark_project(c: &mut Criterion) {
         b.iter_with_setup(
             || TrieScanProject::new(&join_trie, ProjectReordering::from_vector(vec![0, 1], 4)),
             |project_iter| {
-                let _ = materialize(&mut TrieScanEnum::TrieScanProject(project_iter));
+                let _ = materialize(&mut TrieScanPrune::new(TrieScanEnum::TrieScanProject(
+                    project_iter,
+                )));
             },
         );
     });
@@ -210,7 +219,9 @@ fn benchmark_project(c: &mut Criterion) {
         b.iter_with_setup(
             || TrieScanProject::new(&join_trie, ProjectReordering::from_vector(vec![2, 3], 4)),
             |project_iter| {
-                let _ = materialize(&mut TrieScanEnum::TrieScanProject(project_iter));
+                let _ = materialize(&mut TrieScanPrune::new(TrieScanEnum::TrieScanProject(
+                    project_iter,
+                )));
             },
         );
     });
@@ -219,7 +230,9 @@ fn benchmark_project(c: &mut Criterion) {
         b.iter_with_setup(
             || TrieScanProject::new(&trie_b, ProjectReordering::from_vector(vec![0, 2, 1], 4)),
             |project_iter| {
-                let _ = materialize(&mut TrieScanEnum::TrieScanProject(project_iter));
+                let _ = materialize(&mut TrieScanPrune::new(TrieScanEnum::TrieScanProject(
+                    project_iter,
+                )));
             },
         );
     });
@@ -227,7 +240,9 @@ fn benchmark_project(c: &mut Criterion) {
         b.iter_with_setup(
             || TrieScanProject::new(&trie_b, ProjectReordering::from_vector(vec![1, 0, 2], 4)),
             |project_iter| {
-                let _ = materialize(&mut TrieScanEnum::TrieScanProject(project_iter));
+                let _ = materialize(&mut TrieScanPrune::new(TrieScanEnum::TrieScanProject(
+                    project_iter,
+                )));
             },
         );
     });
@@ -235,7 +250,9 @@ fn benchmark_project(c: &mut Criterion) {
         b.iter_with_setup(
             || TrieScanProject::new(&trie_b, ProjectReordering::from_vector(vec![2, 1, 0], 4)),
             |project_iter| {
-                let _ = materialize(&mut TrieScanEnum::TrieScanProject(project_iter));
+                let _ = materialize(&mut TrieScanPrune::new(TrieScanEnum::TrieScanProject(
+                    project_iter,
+                )));
             },
         );
     });
@@ -294,7 +311,9 @@ fn benchmark_union(c: &mut Criterion) {
                 )
             },
             |union_iter| {
-                let _ = materialize(&mut TrieScanEnum::TrieScanUnion(union_iter));
+                let _ = materialize(&mut TrieScanPrune::new(TrieScanEnum::TrieScanUnion(
+                    union_iter,
+                )));
             },
         );
     });

--- a/src/physical/columnar/adaptive_column_builder.rs
+++ b/src/physical/columnar/adaptive_column_builder.rs
@@ -3,7 +3,9 @@ use crate::physical::datatypes::{
 };
 use std::fmt::Debug;
 
+use super::column_types::interval::{ColumnWithIntervals, ColumnWithIntervalsT};
 use super::column_types::{rle::ColumnBuilderRle, vector::ColumnVector};
+
 use super::traits::{
     column::{Column, ColumnEnum},
     columnbuilder::ColumnBuilder,
@@ -265,6 +267,30 @@ impl ColumnBuilderAdaptiveT {
             Self::I64(cb) => cb.count(),
             Self::Float(cb) => cb.count(),
             Self::Double(cb) => cb.count(),
+        }
+    }
+
+    /// Turn the column builder into the finalized Column
+    pub fn finalize(self, interval_column: ColumnBuilderAdaptive<usize>) -> ColumnWithIntervalsT {
+        match self {
+            ColumnBuilderAdaptiveT::U32(c) => ColumnWithIntervalsT::U32(ColumnWithIntervals::new(
+                c.finalize(),
+                interval_column.finalize(),
+            )),
+            ColumnBuilderAdaptiveT::U64(c) => ColumnWithIntervalsT::U64(ColumnWithIntervals::new(
+                c.finalize(),
+                interval_column.finalize(),
+            )),
+            ColumnBuilderAdaptiveT::I64(c) => ColumnWithIntervalsT::I64(ColumnWithIntervals::new(
+                c.finalize(),
+                interval_column.finalize(),
+            )),
+            ColumnBuilderAdaptiveT::Float(c) => ColumnWithIntervalsT::Float(
+                ColumnWithIntervals::new(c.finalize(), interval_column.finalize()),
+            ),
+            ColumnBuilderAdaptiveT::Double(c) => ColumnWithIntervalsT::Double(
+                ColumnWithIntervals::new(c.finalize(), interval_column.finalize()),
+            ),
         }
     }
 }

--- a/src/physical/tabular/operations.rs
+++ b/src/physical/tabular/operations.rs
@@ -3,7 +3,6 @@
 /// Module for materializing tries
 pub mod materialize;
 pub use materialize::materialize;
-pub use materialize::materialize_subset;
 
 /// Module for defining [`TrieScanProject`]
 pub mod triescan_project;

--- a/src/physical/tabular/operations/materialize.rs
+++ b/src/physical/tabular/operations/materialize.rs
@@ -1,260 +1,87 @@
 use crate::physical::{
     columnar::{
         adaptive_column_builder::{ColumnBuilderAdaptive, ColumnBuilderAdaptiveT},
-        column_types::interval::{ColumnWithIntervals, ColumnWithIntervalsT},
-        traits::{columnbuilder::ColumnBuilder, columnscan::ColumnScan},
+        traits::columnbuilder::ColumnBuilder,
     },
-    datatypes::{Double, Float, StorageTypeName},
-    tabular::{
-        table_types::trie::Trie,
-        traits::triescan::{TrieScan, TrieScanEnum},
-    },
+    datatypes::StorageTypeName,
+    tabular::{table_types::trie::Trie, traits::trie_scan::TrieScan},
 };
 
 /// Given a TrieScan iterator, materialize its content into a trie
-/// If `picked_columns` is provided we will only store values for columns
-/// for which the respective entry in this vector is set to true
-/// If `check_empty` is set to true it will only try to find the first entry and then abort
-pub fn materialize_inner(
-    trie_scan: &mut TrieScanEnum,
-    picked_columns: Option<Vec<bool>>,
-    cut_bottom: usize,
-    check_empty: bool,
-) -> Option<Trie> {
-    // Keep track of the number of next calls; used for logging
-    let mut next_count: usize = 0;
+/// For the last `cut` layers only checks the existence of a value and does not materialize it fully.
+pub fn materialize_up_to(trie_scan: &mut impl TrieScan, cut: usize) -> Option<Trie> {
+    let num_columns = trie_scan.column_types().len() - cut;
 
-    // Used types will be the same as in the trie scan
-    let column_types = trie_scan.get_types().clone();
-    let arity = column_types.len();
-
-    if arity == 0 {
-        return Some(Trie::new(vec![]));
-    }
-
-    // Setup column builders
-    let mut result_columns = Vec::<ColumnWithIntervalsT>::with_capacity(arity);
-    let mut data_column_builders = Vec::<ColumnBuilderAdaptiveT>::new();
-    let mut intervals_column_builders = Vec::<ColumnBuilderAdaptive<usize>>::new();
-
-    log::trace!("Column types: {:?}", column_types);
-
-    for column_type in &column_types {
-        intervals_column_builders.push(ColumnBuilderAdaptive::default());
-
-        macro_rules! init_builder_for_datatype {
-            ($variant:ident) => {{
-                data_column_builders.push(ColumnBuilderAdaptiveT::$variant(
-                    ColumnBuilderAdaptive::default(),
-                ))
-            }};
-        }
-
-        match column_type {
-            StorageTypeName::U32 => init_builder_for_datatype!(U32),
-            StorageTypeName::U64 => init_builder_for_datatype!(U64),
-            StorageTypeName::I64 => init_builder_for_datatype!(I64),
-            StorageTypeName::Float => init_builder_for_datatype!(Float),
-            StorageTypeName::Double => init_builder_for_datatype!(Double),
-        }
-    }
-
-    // Consider the path we currently span in the depth-first search.
-    // current_row[i] = true means that for the ith value in the current path
-    // we have already reached the bottom starting from that value (by an alternative path)
-    // meaning that this value has to be added before leaving it
-    let mut current_row: Vec<bool> = vec![false; arity - 1];
-
-    // Contains for each layer the current number of entries in the data vector
-    let mut current_num_elements: Vec<usize> = vec![0usize; arity];
-
-    // Contains for each layer the number of entries in the data vector at the last time the interval column has been updated
-    let mut prev_num_elements: Vec<usize> = vec![0usize; arity];
-
-    // Current layer in the depth-first search
-    let mut current_layer: usize = 0;
-
-    // Whether the result contians at least one element
-    let mut is_empty = true;
-
-    // Iterate through the trie_scan in a depth-first-search manner
-    trie_scan.down();
-    loop {
-        // It is important to know when we reached the bottom as only those values will be added to the result
-        let is_last_layer = current_layer >= arity - 1;
-
-        // Whether the content of this layer is important for the overall output
-        // If this layer is "cut" then it is enough to check whether there is at least one value in this layer
-        let is_layer_cut = current_layer >= arity - cut_bottom;
-
-        // In each loop iteration we perform a sideways step, then if not on the last layer go down
-        // (unless a sideways step is impossible in which case we go up)
-        // next_value is the value on which the down operation will be performed
-        // current_value is the value we are leaving behind
-        // If there exists a path from current_value to the bottom (which we keep track of with the current_row variable)
-        // then it has to be added to a column builder
-        let current_value = trie_scan.current_scan().unwrap().current();
-
-        let next_value = if is_layer_cut
-            && (is_last_layer || current_row[current_layer])
-            && (!is_last_layer || current_value.is_some())
-        {
-            // We ignore the rest of the layer if
-            // * This layer is cut
-            // * If it is not the last layer but `current_row` indicates that `current_value` should be part of the output
-            // * If it is the last layer and the previous iteration already proved the existence of a value on this layer
-            None
-        } else {
-            next_count += 1;
-            trie_scan.current_scan().unwrap().next()
-        };
-
-        if let Some(val) = current_value {
-            if is_last_layer || current_row[current_layer] {
-                let is_picked = if let Some(picked_columns) = &picked_columns {
-                    picked_columns[current_layer]
-                } else {
-                    true
-                };
-
-                current_num_elements[current_layer] += 1;
-
-                if is_picked {
-                    log::trace!("add [layer {current_layer}] <- {val} {trie_scan:?}");
-                    data_column_builders[current_layer].add(val);
-                }
-            }
-
-            if !is_last_layer {
-                current_row[current_layer] = false;
-            }
-        } else if is_last_layer && next_value.is_some() {
-            current_row.fill(true);
-            is_empty = false;
-
-            // At this point we know that the result will contain at least one variable
-            if check_empty {
-                break;
-            }
-        }
-
-        if next_value.is_none() {
-            // Next value being None means that the currently built sorted interval of values is finished
-            // and we therefore know the starting point of the next interval
-            let current_data_len = current_num_elements[current_layer];
-            let prev_data_len = &mut prev_num_elements[current_layer];
-
-            // Check if new values have been added since last time
-            if current_data_len > *prev_data_len {
-                intervals_column_builders[current_layer].add(*prev_data_len);
-                *prev_data_len = current_data_len;
-            }
-
-            // Since the next value is None we need to go up
-            // If we are in the first layer then this means that the computation is finished
-            if current_layer == 0 {
-                break;
-            }
-
-            trie_scan.up();
-            current_layer -= 1;
-
-            // So that we don't go up and down in the same loop iteration
-            continue;
-        }
-
-        if !is_last_layer {
-            trie_scan.down();
-            current_layer += 1;
-        }
-    }
-
-    if !is_empty {
-        // Collect data from column builders
-        for column_type in column_types {
-            macro_rules! finalize_for_datatype {
-                ($variant:ident, $type:ty) => {{
-                    let current_data_builder: ColumnBuilderAdaptive<$type> =
-                        if let ColumnBuilderAdaptiveT::$variant(cb) = data_column_builders.remove(0)
-                        {
-                            cb
-                        } else {
-                            panic!("Expected a column scan of type {}", stringify!($type));
-                        };
-                    let current_interval_builder = intervals_column_builders.remove(0);
-
-                    let next_interval_column =
-                        ColumnWithIntervalsT::$variant(ColumnWithIntervals::new(
-                            current_data_builder.finalize(),
-                            current_interval_builder.finalize(),
-                        ));
-
-                    result_columns.push(next_interval_column);
+    let mut data_column_builders: Vec<_> = trie_scan
+        .column_types()
+        .iter()
+        .take(num_columns)
+        .map(|column_type| {
+            macro_rules! init_builder_for_datatype {
+                ($variant:ident) => {{
+                    ColumnBuilderAdaptiveT::$variant(ColumnBuilderAdaptive::default())
                 }};
             }
 
             match column_type {
-                StorageTypeName::U32 => finalize_for_datatype!(U32, u32),
-                StorageTypeName::U64 => finalize_for_datatype!(U64, u64),
-                StorageTypeName::I64 => finalize_for_datatype!(I64, i64),
-                StorageTypeName::Float => finalize_for_datatype!(Float, Float),
-                StorageTypeName::Double => finalize_for_datatype!(Double, Double),
+                StorageTypeName::U32 => init_builder_for_datatype!(U32),
+                StorageTypeName::U64 => init_builder_for_datatype!(U64),
+                StorageTypeName::I64 => init_builder_for_datatype!(I64),
+                StorageTypeName::Float => init_builder_for_datatype!(Float),
+                StorageTypeName::Double => init_builder_for_datatype!(Double),
             }
+        })
+        .collect();
+
+    let mut intervals_column_builder = Vec::with_capacity(num_columns);
+    intervals_column_builder.resize_with(num_columns, ColumnBuilderAdaptive::<usize>::default);
+
+    let mut changed_layer = trie_scan.advance_on_layer(num_columns - 1)?;
+    debug_assert_eq!(changed_layer, 0);
+    intervals_column_builder[0].add(0);
+
+    loop {
+        for i in changed_layer..num_columns {
+            if i < num_columns - 1 {
+                intervals_column_builder[i + 1].add(data_column_builders[i + 1].count())
+            }
+            data_column_builders[i].add(trie_scan.current(i));
         }
 
-        let result = Trie::new(result_columns);
-
-        log::info!(
-            "Materialize: Next: {next_count}, Elements: {}, Quotient: {}",
-            result.num_elements(),
-            num::ToPrimitive::to_f64(&next_count).unwrap()
-                / num::ToPrimitive::to_f64(&result.num_elements()).unwrap()
-        );
-
-        return Some(result);
+        if let Some(next_changed_layer) = trie_scan.advance_on_layer(num_columns - 1) {
+            changed_layer = next_changed_layer;
+        } else {
+            break;
+        }
     }
 
-    None
+    let columns = data_column_builders
+        .into_iter()
+        .zip(intervals_column_builder.into_iter())
+        .map(|(d, i)| d.finalize(i));
+
+    Some(columns.collect())
 }
 
 /// Given a TrieScan iterator, materialize its content into a trie
-pub fn materialize(trie_scan: &mut TrieScanEnum) -> Option<Trie> {
-    materialize_inner(trie_scan, None, 0, false)
-}
-
-/// Given a TrieScan iterator, materialize its content into a trie
-/// For the last `cut` layers only checks the existence of a value and does not materialize it fully.
-pub fn materialize_up_to(trie_scan: &mut TrieScanEnum, cut: usize) -> Option<Trie> {
-    materialize_inner(trie_scan, None, cut, false)
+pub fn materialize(trie_scan: &mut impl TrieScan) -> Option<Trie> {
+    materialize_up_to(trie_scan, 0)
 }
 
 /// Tests whether an iterator is empty by materializing it until the first element
-pub fn scan_is_empty(trie_scan: &mut TrieScanEnum) -> bool {
-    materialize_inner(trie_scan, None, 0, true).is_some()
-}
-
-/// Materialize the content of an iterator into a trie.
-///
-/// Given a TrieScan iterator, materialize its content into a trie.
-/// Setting `picked_columns[i]` to false means that the ith column will have an empty data vector
-/// Passing None is equivalent to passing a vector containing only true
-/// TODO: For now this function behaves the same as materialize
-/// because it doesn't work with the current implementation of project.
-/// This function might also be removed entirely in the future since it didn't have that much of an performance impact.
-pub fn materialize_subset(
-    trie_scan: &mut TrieScanEnum,
-    _picked_columns: Vec<bool>,
-) -> Option<Trie> {
-    materialize_inner(trie_scan, None, 0, false)
+pub fn scan_is_empty(trie_scan: &mut impl TrieScan) -> bool {
+    trie_scan
+        .advance_on_layer(trie_scan.column_types().len())
+        .is_some()
 }
 
 #[cfg(test)]
 mod test {
     use super::materialize;
     use crate::physical::columnar::traits::column::Column;
-    use crate::physical::tabular::operations::{JoinBindings, TrieScanJoin};
+    use crate::physical::tabular::operations::{JoinBindings, TrieScanJoin, TrieScanPrune};
     use crate::physical::tabular::table_types::trie::{Trie, TrieScanGeneric};
-    use crate::physical::tabular::traits::triescan::TrieScanEnum;
+    use crate::physical::tabular::traits::partial_trie_scan::TrieScanEnum;
     use crate::physical::util::test_util::make_column_with_intervals_t;
     use test_log::test;
 
@@ -274,9 +101,9 @@ mod test {
         let column_vec = vec![column_fst, column_snd, column_trd];
 
         let trie = Trie::new(column_vec);
-        let mut trie_iter = TrieScanEnum::TrieScanGeneric(TrieScanGeneric::new(&trie));
+        let trie_iter = TrieScanEnum::TrieScanGeneric(TrieScanGeneric::new(&trie));
 
-        let materialized_trie = materialize(&mut trie_iter).unwrap();
+        let materialized_trie = materialize(&mut TrieScanPrune::new(trie_iter)).unwrap();
 
         let mat_in_col_fst = materialized_trie.get_column(0).as_u64().unwrap();
         let mat_in_col_snd = materialized_trie.get_column(1).as_u64().unwrap();
@@ -337,7 +164,7 @@ mod test {
         let trie_a = Trie::new(vec![column_a_x, column_a_y]);
         let trie_b = Trie::new(vec![column_b_y, column_b_z]);
 
-        let mut join_iter = TrieScanEnum::TrieScanJoin(TrieScanJoin::new(
+        let join_iter = TrieScanEnum::TrieScanJoin(TrieScanJoin::new(
             vec![
                 TrieScanEnum::TrieScanGeneric(TrieScanGeneric::new(&trie_a)),
                 TrieScanEnum::TrieScanGeneric(TrieScanGeneric::new(&trie_b)),
@@ -345,7 +172,7 @@ mod test {
             &JoinBindings::new(vec![vec![0, 1], vec![1, 2]]),
         ));
 
-        let materialized_join = materialize(&mut join_iter).unwrap();
+        let materialized_join = materialize(&mut TrieScanPrune::new(join_iter)).unwrap();
 
         let mat_in_col_fst = materialized_join.get_column(0).as_u64().unwrap();
         let mat_in_col_snd = materialized_join.get_column(1).as_u64().unwrap();

--- a/src/physical/tabular/operations/triescan_append.rs
+++ b/src/physical/tabular/operations/triescan_append.rs
@@ -22,8 +22,8 @@ use crate::{
         tabular::{
             table_types::trie::Trie,
             traits::{
+                partial_trie_scan::{PartialTrieScan, TrieScanEnum},
                 table::Table,
-                triescan::{TrieScan, TrieScanEnum},
             },
         },
     },
@@ -193,7 +193,7 @@ pub fn trie_append(
     Trie::new(Vec::<ColumnWithIntervalsT>::from(new_columns))
 }
 
-/// [`TrieScan`] which appends columns to an existing [`TrieScan`].
+/// [`PartialTrieScan`] which appends columns to an existing [`PartialTrieScan`].
 #[derive(Debug)]
 pub struct TrieScanAppend<'a> {
     /// Trie scans to which new columns will be appended.
@@ -376,7 +376,7 @@ impl<'a> TrieScanAppend<'a> {
     }
 }
 
-impl<'a> TrieScan<'a> for TrieScanAppend<'a> {
+impl<'a> PartialTrieScan<'a> for TrieScanAppend<'a> {
     fn up(&mut self) {
         if self.current_layer.is_none() {
             return;
@@ -439,7 +439,7 @@ mod test {
         tabular::{
             operations::triescan_append::{AppendInstruction, TrieScanAppend},
             table_types::trie::{Trie, TrieScanGeneric},
-            traits::triescan::{TrieScan, TrieScanEnum},
+            traits::partial_trie_scan::{PartialTrieScan, TrieScanEnum},
         },
         util::{make_column_with_intervals_t, test_util::make_column_with_intervals_int_t},
     };

--- a/src/physical/tabular/operations/triescan_minus.rs
+++ b/src/physical/tabular/operations/triescan_minus.rs
@@ -4,25 +4,25 @@ use crate::physical::{
         traits::columnscan::{ColumnScan, ColumnScanCell, ColumnScanEnum, ColumnScanT},
     },
     datatypes::{Double, Float, StorageTypeName},
-    tabular::traits::triescan::{TrieScan, TrieScanEnum},
+    tabular::traits::partial_trie_scan::{PartialTrieScan, TrieScanEnum},
     util::mapping::permutation::Permutation,
 };
 use std::cell::UnsafeCell;
 use std::fmt::Debug;
 
-/// [`TrieScan`] that subtracts from a "main" [`TrieScan`] a list of "subtract" [`TrieScan`],
+/// [`PartialTrieScan`] that subtracts from a "main" [`PartialTrieScan`] a list of "subtract" [`PartialTrieScan`],
 /// i.e. the results contains all elements that are in main but not in one of the subtract scans.
 /// This can also handle subtracting tables of different arities.
 #[derive(Debug)]
 pub struct TrieScanSubtract<'a> {
-    /// [`TrieScan`] from which elements are being subtracted
+    /// [`PartialTrieScan`] from which elements are being subtracted
     trie_main: Box<TrieScanEnum<'a>>,
     /// Elements that are subtracted
     tries_subtract: Vec<TrieScanEnum<'a>>,
 
-    /// For each [`TrieScan`] in `trie_subtract`, additional information relevant for this scan.
+    /// For each [`PartialTrieScan`] in `trie_subtract`, additional information relevant for this scan.
     infos: Vec<SubtractInfo>,
-    /// For each [`TrieScan`] in `trie_subtract`, which layer this trie scan is currently on.
+    /// For each [`PartialTrieScan`] in `trie_subtract`, which layer this trie scan is currently on.
     subtract_current_layers: Vec<usize>,
 
     /// Current layer of this scan.
@@ -175,7 +175,7 @@ impl<'a> TrieScanSubtract<'a> {
     }
 }
 
-impl<'a> TrieScan<'a> for TrieScanSubtract<'a> {
+impl<'a> PartialTrieScan<'a> for TrieScanSubtract<'a> {
     fn up(&mut self) {
         debug_assert!(self.current_layer.is_some());
         let current_layer = self.current_layer.unwrap();
@@ -272,10 +272,10 @@ impl<'a> TrieScan<'a> for TrieScanSubtract<'a> {
     }
 }
 
-/// [`TrieScan`] containg all elements from a "left" [`TrieScan`] that are not in the "right" [`TrieScan`]  
+/// [`PartialTrieScan`] containg all elements from a "left" [`PartialTrieScan`] that are not in the "right" [`PartialTrieScan`]  
 #[derive(Debug)]
 pub struct TrieScanMinus<'a> {
-    /// [`TrieScan`] from which elements are being subtracted
+    /// [`PartialTrieScan`] from which elements are being subtracted
     trie_left: Box<TrieScanEnum<'a>>,
 
     /// Elements that are subtracted
@@ -366,7 +366,7 @@ impl<'a> TrieScanMinus<'a> {
     }
 }
 
-impl<'a> TrieScan<'a> for TrieScanMinus<'a> {
+impl<'a> PartialTrieScan<'a> for TrieScanMinus<'a> {
     fn up(&mut self) {
         self.layer_left = self
             .layer_left
@@ -438,7 +438,7 @@ mod test {
     use crate::physical::columnar::traits::columnscan::ColumnScanT;
     use crate::physical::tabular::operations::triescan_minus::{SubtractInfo, TrieScanSubtract};
     use crate::physical::tabular::table_types::trie::{Trie, TrieScanGeneric};
-    use crate::physical::tabular::traits::triescan::{TrieScan, TrieScanEnum};
+    use crate::physical::tabular::traits::partial_trie_scan::{PartialTrieScan, TrieScanEnum};
     use crate::physical::util::test_util::make_column_with_intervals_t;
     use test_log::test;
 

--- a/src/physical/tabular/operations/triescan_nulls.rs
+++ b/src/physical/tabular/operations/triescan_nulls.rs
@@ -6,10 +6,10 @@ use crate::physical::{
         traits::columnscan::{ColumnScan, ColumnScanCell, ColumnScanEnum, ColumnScanT},
     },
     datatypes::StorageTypeName,
-    tabular::traits::triescan::{TrieScan, TrieScanEnum},
+    tabular::traits::partial_trie_scan::{PartialTrieScan, TrieScanEnum},
 };
 
-/// [`TrieScan`] which appends columns with nulls at the end of another [`TrieScan`].
+/// [`PartialTrieScan`] which appends columns with nulls at the end of another [`PartialTrieScan`].
 #[derive(Debug)]
 pub struct TrieScanNulls<'a> {
     /// Trie scans to which new columns will be appended.
@@ -86,7 +86,7 @@ impl<'a> TrieScanNulls<'a> {
     }
 }
 
-impl<'a> TrieScan<'a> for TrieScanNulls<'a> {
+impl<'a> PartialTrieScan<'a> for TrieScanNulls<'a> {
     fn up(&mut self) {
         if self.current_layer.is_none() {
             return;
@@ -133,7 +133,7 @@ mod test {
         columnar::traits::columnscan::ColumnScanT,
         tabular::{
             table_types::trie::{Trie, TrieScanGeneric},
-            traits::triescan::{TrieScan, TrieScanEnum},
+            traits::partial_trie_scan::{PartialTrieScan, TrieScanEnum},
         },
         util::make_column_with_intervals_t,
     };

--- a/src/physical/tabular/operations/triescan_select.rs
+++ b/src/physical/tabular/operations/triescan_select.rs
@@ -5,7 +5,7 @@ use crate::physical::{
     },
     datatypes::{DataValueT, StorageTypeName, StorageValueT},
     management::database::Dict,
-    tabular::traits::triescan::{TrieScan, TrieScanEnum},
+    tabular::traits::partial_trie_scan::{PartialTrieScan, TrieScanEnum},
     util::interval::{Interval, IntervalBound},
 };
 use std::cell::UnsafeCell;
@@ -127,7 +127,7 @@ impl<'a> TrieScanSelectEqual<'a> {
     }
 }
 
-impl<'a> TrieScan<'a> for TrieScanSelectEqual<'a> {
+impl<'a> PartialTrieScan<'a> for TrieScanSelectEqual<'a> {
     fn up(&mut self) {
         self.current_layer = self
             .current_layer
@@ -297,7 +297,7 @@ impl<'a> TrieScanSelectValue<'a> {
     }
 }
 
-impl<'a> TrieScan<'a> for TrieScanSelectValue<'a> {
+impl<'a> PartialTrieScan<'a> for TrieScanSelectValue<'a> {
     fn up(&mut self) {
         self.current_layer = self
             .current_layer
@@ -337,7 +337,7 @@ mod test {
     use crate::physical::datatypes::DataValueT;
     use crate::physical::management::database::Dict;
     use crate::physical::tabular::table_types::trie::{Trie, TrieScanGeneric};
-    use crate::physical::tabular::traits::triescan::{TrieScan, TrieScanEnum};
+    use crate::physical::tabular::traits::partial_trie_scan::{PartialTrieScan, TrieScanEnum};
     use crate::physical::util::interval::Interval;
     use crate::physical::util::test_util::make_column_with_intervals_t;
     use test_log::test;

--- a/src/physical/tabular/operations/triescan_union.rs
+++ b/src/physical/tabular/operations/triescan_union.rs
@@ -4,12 +4,12 @@ use crate::physical::{
         traits::columnscan::{ColumnScan, ColumnScanCell, ColumnScanEnum, ColumnScanT},
     },
     datatypes::{Double, Float, StorageTypeName},
-    tabular::traits::triescan::{TrieScan, TrieScanEnum},
+    tabular::traits::partial_trie_scan::{PartialTrieScan, TrieScanEnum},
 };
 use std::cell::UnsafeCell;
 use std::fmt::Debug;
 
-/// [`TrieScan`] representing a union of other trie iterators
+/// [`PartialTrieScan`] representing a union of other trie iterators
 #[derive(Debug)]
 pub struct TrieScanUnion<'a> {
     /// Trie scans for which the join is computed
@@ -85,7 +85,7 @@ impl<'a> TrieScanUnion<'a> {
     }
 }
 
-impl<'a> TrieScan<'a> for TrieScanUnion<'a> {
+impl<'a> PartialTrieScan<'a> for TrieScanUnion<'a> {
     fn up(&mut self) {
         let up_layer = self
             .current_layer
@@ -152,7 +152,7 @@ mod test {
     use crate::physical::columnar::traits::columnscan::ColumnScanT;
     use crate::physical::tabular::operations::{JoinBindings, TrieScanJoin};
     use crate::physical::tabular::table_types::trie::{Trie, TrieScanGeneric};
-    use crate::physical::tabular::traits::triescan::{TrieScan, TrieScanEnum};
+    use crate::physical::tabular::traits::partial_trie_scan::{PartialTrieScan, TrieScanEnum};
     use crate::physical::util::test_util::make_column_with_intervals_t;
     use test_log::test;
 

--- a/src/physical/tabular/traits.rs
+++ b/src/physical/tabular/traits.rs
@@ -6,5 +6,8 @@ pub mod table;
 /// Module for defining [`TableSchema`][table_schema::TableSchema]
 pub mod table_schema;
 
-/// Module for defining [`TrieScan`][triescan::TrieScan]
-pub mod triescan;
+/// Module defining the [`PartialTrieScan`][partial_trie_scan::PartialTrieScan] interface
+pub mod partial_trie_scan;
+
+/// Module defining the [`TrieScan`][trie_scan::TrieScan] interface
+pub mod trie_scan;

--- a/src/physical/tabular/traits/partial_trie_scan.rs
+++ b/src/physical/tabular/traits/partial_trie_scan.rs
@@ -14,7 +14,7 @@ use std::fmt::Debug;
 /// Iterator for a Trie datastructure.
 /// Allows for vertical traversal through the tree and can return
 /// its current position as a [`ColumnScanT`] object.
-pub trait TrieScan<'a>: Debug {
+pub trait PartialTrieScan<'a>: Debug {
     /// Return to the upper layer.
     /// This may only be called if the trie scan is not already at the topmost layer. TODO: Is this restriction required? Check implementations if you want to change this
     fn up(&mut self);
@@ -74,7 +74,7 @@ generate_forwarder!(forward_to_scan;
     TrieScanSubtract
 );
 
-impl<'a> TrieScan<'a> for TrieScanEnum<'a> {
+impl<'a> PartialTrieScan<'a> for TrieScanEnum<'a> {
     fn up(&mut self) {
         forward_to_scan!(self, up)
     }

--- a/src/physical/tabular/traits/trie_scan.rs
+++ b/src/physical/tabular/traits/trie_scan.rs
@@ -1,0 +1,22 @@
+use crate::physical::datatypes::{StorageTypeName, StorageValueT};
+
+/// An iterator over a trie, which can call next on every layer of the trie
+pub trait TrieScan {
+    /// Advance trie at the specified layer. This might cause calls to next
+    /// at layers above the specified layer. If there is no next element at
+    /// the specified layer, returns none. Otherwise returns the index of the
+    /// uppermost changed layer.
+    fn advance_on_layer(&mut self, layer: usize) -> Option<usize>;
+
+    /// After a call to [TrieScan::advance_on_layer], this returns the current
+    /// value the specified layer. This is only allowed to call, if [TrieScan::advance_on_layer]
+    /// returned [Some].
+    ///
+    /// # Panics
+    /// If there is no current element ([TrieScan::advance_on_layer] was not
+    /// called or returned [None]).
+    fn current(&mut self, layer: usize) -> StorageValueT;
+
+    /// Returns the number of layers of the current trie scan
+    fn column_types(&self) -> &[StorageTypeName];
+}


### PR DESCRIPTION
Fixes an inefficiency were currently, every time combine is called, a union of all single tables is computed. In particular, calling `combine_tables` twice computes the same table twice and appends it twice to the sub-table handler.