### PR TITLE
Data value api

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -8,7 +8,7 @@
 //! # fn main() {}
 //! # #[cfg(not(miri))]
 //! # fn main() {
-//! use nemo::api::{load,reason,output_predicates,write};
+//! use nemo::api::{load, reason, output_predicates, write};
 //! # let path = String::from("./resources/testcases/lcs-diff-computation/run-lcs-10.rls");
 //! // assume path is a string with the path to a rules file
 //! let mut engine = load(path.into()).unwrap();
@@ -66,12 +66,12 @@ pub fn load_string(input: String) -> Result<Engine, Error> {
 /// Executes the reasoning process of the [`Engine`].
 ///
 /// # Note
-/// If there have been `@source` routines in the parsed rules, all relative paths are resolved with the current working directory
+/// If there are `@source` routines in the parsed rules, all relative paths are resolved with the current working directory
 pub fn reason(engine: &mut Engine) -> Result<(), Error> {
     engine.execute()
 }
 
-/// Get a [`Vec`] of all output predicates, that are computed by the engine.
+/// Get a [`Vec`] of all output predicates that are computed by the engine.
 pub fn output_predicates(engine: &Engine) -> Vec<Identifier> {
     engine.program().output_predicates().collect()
 }

--- a/src/api.rs
+++ b/src/api.rs
@@ -75,7 +75,7 @@ pub fn output_predicates(engine: &Engine) -> Vec<Identifier> {
     engine.program().output_predicates().collect()
 }
 
-/// Writes all result [`predicates`][Predicate] in the vector `predicates` into the directory specified in `path`.
+/// Writes all result [`predicates`][Identifier] in the vector `predicates` into the directory specified in `path`.
 pub fn write(path: String, engine: &mut Engine, predicates: Vec<Identifier>) -> Result<(), Error> {
     let output_dir = PathBuf::from(path);
     let file_manager = OutputFileManager::try_new(output_dir, true, false)?;

--- a/src/api.rs
+++ b/src/api.rs
@@ -8,18 +8,19 @@
 //! # fn main() {}
 //! # #[cfg(not(miri))]
 //! # fn main() {
-//! use nemo::api::{load,reason,write};
+//! use nemo::api::{load,reason,output_predicates,write};
 //! # let path = String::from("./resources/testcases/lcs-diff-computation/run-lcs-10.rls");
 //! // assume path is a string with the path to a rules file
 //! let mut engine = load(path.into()).unwrap();
 //! # let cur_dir = std::env::current_dir().unwrap();
 //! # std::env::set_current_dir("./resources/testcases/lcs-diff-computation/").unwrap();
 //! // reasoning on the rule file
-//! let results = reason(&mut engine).unwrap();
+//! reason(&mut engine).unwrap();
 //! # std::env::set_current_dir(cur_dir).unwrap();
 //! // write the results to a temporary directory
 //! let temp_dir = TempDir::new().unwrap();
-//! write(temp_dir.to_str().unwrap().to_string(), &mut engine, results).unwrap();
+//! let predicates = output_predicates(&engine);
+//! write(temp_dir.to_str().unwrap().to_string(), &mut engine, predicates).unwrap();
 //! # }
 //! ```
 

--- a/src/io.rs
+++ b/src/io.rs
@@ -28,7 +28,7 @@ pub trait RecordWriter {
 
     /// Write a trie.
     fn write_trie(&mut self, mut trie: impl TrieSerializer) -> Result<(), Error> {
-        while let Some(record) = trie.next_record() {
+        while let Some(record) = trie.next_serialized() {
             self.write_record(record)?;
         }
 

--- a/src/logical/execution/execution_engine.rs
+++ b/src/logical/execution/execution_engine.rs
@@ -250,7 +250,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
     }
 
     /// Get a reference to the loaded program.
-    pub fn program(&self) -> &Program {
+    pub fn program(&self) -> &ChaseProgram {
         &self.program
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,12 +144,10 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
             .start();
         log::info!("writing output");
 
-        let results = engine.combine_results()?;
+        for predicate in engine.program().output_predicates() {
+            let mut writer = output_manager.create_file_writer(&predicate)?;
 
-        for predicate in results {
-            let mut writer = output_manager.create_file_writer(predicate.identifier())?;
-
-            if let Some(table) = engine.table_serializer(predicate) {
+            if let Some(table) = engine.table_serializer(predicate)? {
                 writer.write_trie(table)?;
             }
         }

--- a/src/physical/dictionary/value_serializer.rs
+++ b/src/physical/dictionary/value_serializer.rs
@@ -9,7 +9,7 @@ use crate::physical::{
 use super::Dictionary;
 
 /// Helper trait for mapping [`StorageValueT`] back into some (higher level) value space
-/// by virtue of the schema index, a value appears at (inside a table).
+/// by virtue of the schema index that a value appears at (inside a table).
 pub trait StorageValueMapping<Output> {
     /// Map the [`StorageValueT`], which appeared at index `layer` to the Output type.
     fn map(&self, value: StorageValueT, layer: usize) -> Output;


### PR DESCRIPTION
Adds the possibility for an `ExecutionEngine` to return an Iterator over Vecs of DataStorageValues. Also gets rid of the specialized `TrieRecords` struct, which can now be implemented by TrieScanPrune.