### PR TITLE
Change the parameter type of `ExecutionEngine` to accept `ChaseProgram`

### DIFF
--- a/src/api.rs
+++ b/src/api.rs
@@ -60,7 +60,7 @@ pub fn load(file: PathBuf) -> Result<Engine, Error> {
 /// Returns an appropriate [`Error`][crate::error::Error] variant on parsing and feature check issues.
 pub fn load_string(input: String) -> Result<Engine, Error> {
     let program = all_input_consumed(RuleParser::new().parse_program())(&input)?;
-    ExecutionEngine::initialize(program)
+    ExecutionEngine::initialize(program.into())
 }
 
 /// Executes the reasoning process of the [`Engine`].

--- a/src/logical/execution/execution_engine.rs
+++ b/src/logical/execution/execution_engine.rs
@@ -6,7 +6,7 @@ use crate::{
     error::Error,
     io::dsv::DSVReader,
     logical::{
-        model::{chase_model::ChaseProgram, DataSource, Identifier, Program},
+        model::{chase_model::ChaseProgram, DataSource, Identifier},
         program_analysis::analysis::ProgramAnalysis,
         types::LogicalTypeEnum,
         TableManager,
@@ -58,9 +58,7 @@ pub struct ExecutionEngine<RuleSelectionStrategy> {
 
 impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
     /// Initialize [`ExecutionEngine`].
-    pub fn initialize(program: Program) -> Result<Self, Error> {
-        let mut program: ChaseProgram = program.into();
-
+    pub fn initialize(mut program: ChaseProgram) -> Result<Self, Error> {
         program.check_for_unsupported_features()?;
         program.normalize();
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -125,7 +125,7 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
         output_manager.prevent_accidental_overwrite(program.output_predicates())?;
     }
 
-    let mut engine: DefaultExecutionEngine = ExecutionEngine::initialize(program)?;
+    let mut engine: DefaultExecutionEngine = ExecutionEngine::initialize(program.into())?;
 
     TimedCode::instance().sub("Reading & Preprocessing").stop();
     TimedCode::instance().sub("Reasoning").start();


### PR DESCRIPTION
Rational: In the API we probably want to expose `ChaseProgram` rather than `Program`, but then we need to be able to construct an `ExecutionEngine` from that.