### PR TITLE
implement From<String> for Identifier

### DIFF
--- a/src/logical/model/rule_model.rs
+++ b/src/logical/model/rule_model.rs
@@ -41,6 +41,12 @@ impl std::fmt::Display for Identifier {
     }
 }
 
+impl From<String> for Identifier {
+    fn from(value: String) -> Self {
+        Identifier(value)
+    }
+}
+
 /// A qualified predicate name, i.e., a predicate name together with its arity.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, PartialOrd, Ord)]
 pub struct QualifiedPredicateName {


### PR DESCRIPTION
This enables construction of Identifiers for consumers of this crate, which is necessary e.g. to get results of a computation. This should have been part of #242, but got lost while rebasing.