### PR TITLE
create rust-toolchain.toml

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,0 +1,3 @@
+[toolchain]
+channel = "nightly"
+components = [ "rustfmt", "clippy", "rust-docs" ]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
 channel = "nightly"
-components = [ "rustfmt", "clippy", "rust-docs" ]
+components = [ "rustfmt", "clippy", "rust-docs", "miri" ]


### PR DESCRIPTION
The `rust-toolchain.toml` sets the default toolchain to nightly, so a clean checkout of this repository now can be built without running `rustup override set ...`