### PR TITLE
Update flake

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -9,13 +9,33 @@ env:
   RUST_BACKTRACE: 1
 
 jobs:
-  build:
-    name: Build using the nix flake
+  build-nemo:
+    name: Build nemo using the nix flake
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v20
+    - uses: cachix/install-nix-action@v21
       with:
         github_access_token: ${{ secrets.GITHUB_TOKEN }}
-    - run: nix build
+    - run: nix build .#nemo
+
+  build-python:
+    name: Build nemo-python using the nix flake
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v21
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
+    - run: nix build .#nemo-python
+    - run: nix flake check
+
+  evaluate:
+    name: Make sure that the nix flake evaluates
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: cachix/install-nix-action@v21
+      with:
+        github_access_token: ${{ secrets.GITHUB_TOKEN }}
     - run: nix flake check

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -227,7 +227,7 @@ dependencies = [
  "cexpr",
  "clang-sys",
  "clap 2.34.0",
- "env_logger",
+ "env_logger 0.8.4",
  "lazy_static",
  "lazycell",
  "log",
@@ -605,9 +605,9 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b015497079b9a9d69c02ad25de6c0a6edef051ea6360a327d0bd05802ef64ad"
+checksum = "626ae34994d3d8d668f4269922248239db4ae42d538b14c398b74a52208e8086"
 dependencies = [
  "csv-core",
  "itoa",
@@ -720,6 +720,19 @@ checksum = "a19187fea3ac7e84da7dacf48de0c45d63c6a76f9490dae389aead16c243fce3"
 dependencies = [
  "atty",
  "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
  "log",
  "regex",
  "termcolor",
@@ -1265,7 +1278,7 @@ dependencies = [
  "assert_fs",
  "criterion",
  "csv",
- "env_logger",
+ "env_logger 0.10.0",
  "flate2",
  "getrandom",
  "iai",
@@ -1294,7 +1307,7 @@ dependencies = [
  "clap 4.3.0",
  "colored",
  "dir-test",
- "env_logger",
+ "env_logger 0.10.0",
  "log",
  "nemo",
  "predicates",
@@ -1309,7 +1322,7 @@ dependencies = [
  "arbitrary",
  "ascii_tree",
  "bytesize",
- "env_logger",
+ "env_logger 0.10.0",
  "howlong",
  "linked-hash-map",
  "log",
@@ -1814,7 +1827,7 @@ version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "588f6378e4dd99458b60ec275b4477add41ce4fa9f64dcba6f15adccb19b50d6"
 dependencies = [
- "env_logger",
+ "env_logger 0.8.4",
  "log",
  "rand",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-
+resolver = "2"
 members = [
     "nemo",
     "nemo-cli",

--- a/flake.lock
+++ b/flake.lock
@@ -17,16 +17,16 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1683546353,
-        "narHash": "sha256-zEfx6q4fXK5wq+RCsyM0FyWBKNNhHTKMpCWkEpKDe2g=",
+        "lastModified": 1685533922,
+        "narHash": "sha256-y4FCQpYafMQ42l1V+NUrMel9RtFtZo59PzdzflKR/lo=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7629f9b0680d87c7775f3261bee746da5dac76d1",
+        "rev": "3a70dd92993182f8e514700ccf5b1ae9fc8a3b8d",
         "type": "github"
       },
       "original": {
         "owner": "NixOS",
-        "ref": "nixos-22.11",
+        "ref": "nixos-23.05",
         "repo": "nixpkgs",
         "type": "github"
       }
@@ -49,11 +49,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1683598806,
-        "narHash": "sha256-L0tcBTcF6QzFFvWbXO2TXlBszAvxvm3zblYe0iUF/Yk=",
+        "lastModified": 1685587239,
+        "narHash": "sha256-zpOir1AWpWyQscP5dMpqMrCgBzjzH7Wv0FNUsQ0dcS0=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "0cef0c3ed57980dc9a8b916e6b596d7f2f6d34f1",
+        "rev": "acb7e896a73b0cf2c6ffe40b2051eb7f88fc2a10",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -63,6 +63,25 @@ rec {
               buildAndTestSubdir = "nemo-cli";
             };
 
+            nemo-python = pkgs.python3Packages.buildPythonPackage {
+              pname = "nemo-python";
+              src = ./.;
+              inherit (nemo) version meta;
+
+              cargoDeps = platform.importCargoLock { lockFile = ./Cargo.lock; };
+
+              nativeBuildInputs = with platform; [
+                cargoSetupHook
+                maturinBuildHook
+              ];
+              buildAndTestSubdir = "nemo-python";
+
+              doCheck = false; # no python tests yet
+            };
+
+            python3 = pkgs.python3.withPackages (ps: [ nemo-python ]);
+            python = python3;
+
             default = nemo;
           };
 

--- a/flake.nix
+++ b/flake.nix
@@ -3,7 +3,7 @@ rec {
     "nemo, a datalog-based rule engine for fast and scalable analytic data processing in memory";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs/nixos-22.11";
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-23.05";
 
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs = {

--- a/flake.nix
+++ b/flake.nix
@@ -77,6 +77,8 @@ rec {
               pkgs.cargo-audit
               pkgs.cargo-license
               pkgs.gnuplot
+              pkgs.maturin
+              pkgs.python3
             ] ++ (ifNotOn [ "aarch64-linux" "aarch64-darwin" "i686-linux" ]
               [ pkgs.cargo-tarpaulin ])
             ++ (ifNotOn [ "aarch64-darwin" "x86_64-darwin" ] [ pkgs.valgrind ]);

--- a/flake.nix
+++ b/flake.nix
@@ -55,6 +55,12 @@ rec {
                 homepage = "htps://github.com/knowsys/nemo";
                 license = [ pkgs.lib.licenses.asl20 pkgs.lib.licenses.mit ];
               };
+
+              nativeBuildInputs = with platform; [
+                cargoBuildHook
+                cargoCheckHook
+              ];
+              buildAndTestSubdir = "nemo-cli";
             };
 
             default = nemo;

--- a/nemo-python/Cargo.toml
+++ b/nemo-python/Cargo.toml
@@ -9,5 +9,5 @@ name = "nmo_python"
 crate-type = ["cdylib"]
 
 [dependencies]
-pyo3 = "0.18.3"
+pyo3 = { version = "0.18.3", features = [ "extension-module" ] }
 nemo = { path = "../nemo" }


### PR DESCRIPTION
Update the flake:
- bump to nixpkgs 23.05
- fix `nemo` package for new workspace layout (only build `nemo-cli`)
- expose `nemo-python` as a `pythonPackage`
- expose `python3` as a python interpreter with `nemo-python` installed
- build `nemo-python` in the CI as well
- update `Cargo.lock`