### PR TITLE
Unpin nightly toolchain

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "nightly-2023-06-19"
+channel = "nightly"
 components = [ "rustfmt", "clippy", "rust-docs", "miri" ]


### PR DESCRIPTION
With https://github.com/rust-lang/rust/issues/112831 fixed, we can unpin the nightly toolchain again.

Should not be merged before the first 2023-06-20 (or later) nightly build with all required components is available.