### PR TITLE
Speed up loading of `any` Columns

### DIFF
--- a/nemo/src/builder_proxy.rs
+++ b/nemo/src/builder_proxy.rs
@@ -12,7 +12,10 @@ use nemo_physical::{
     datatypes::{DataValueT, Double},
 };
 
-use crate::io::parser::{all_input_consumed, parse_ground_term};
+use crate::io::{
+    formats::rdf_triples::TurtleEncodedRDFTerm,
+    parser::{all_input_consumed, parse_ground_term},
+};
 
 use super::{model::PrimitiveType, model::Term};
 use crate::error::ReadingError;
@@ -53,7 +56,7 @@ impl ColumnBuilderProxy<String> for LogicalAnyColumnBuilderProxy<'_, '_> {
     logical_generic_trait_impl!();
 
     fn add(&mut self, input: String) -> Result<(), ReadingError> {
-        self.commit();
+        <LogicalAnyColumnBuilderProxy<'_, '_> as ColumnBuilderProxy<String>>::commit(self);
 
         let parsed_term =
             all_input_consumed(parse_ground_term(&RefCell::new(HashMap::new())))(input.trim())
@@ -68,6 +71,18 @@ impl ColumnBuilderProxy<String> for LogicalAnyColumnBuilderProxy<'_, '_> {
         };
 
         self.physical.add(parsed_string)
+    }
+}
+
+impl ColumnBuilderProxy<TurtleEncodedRDFTerm> for LogicalAnyColumnBuilderProxy<'_, '_> {
+    logical_generic_trait_impl!();
+
+    fn add(&mut self, input: TurtleEncodedRDFTerm) -> Result<(), ReadingError> {
+        <LogicalAnyColumnBuilderProxy<'_, '_> as ColumnBuilderProxy<TurtleEncodedRDFTerm>>::commit(
+            self,
+        );
+
+        self.physical.add(input.into_normalized_string())
     }
 }
 

--- a/nemo/src/io/formats/rdf_triples.rs
+++ b/nemo/src/io/formats/rdf_triples.rs
@@ -38,6 +38,11 @@ pub(crate) const INITIAL_FOR_SIMPLE_NUMERIC_LITERAL: &[char] = &[
 pub struct TurtleEncodedRDFTerm(String);
 
 impl TurtleEncodedRDFTerm {
+    /// Wrap a syntactically valid Turtle encoding of an RDF term.
+    pub fn new(inner: String) -> Self {
+        Self(inner)
+    }
+
     /// Return the underlying string representation of the term.
     pub fn into_inner(self) -> String {
         self.0

--- a/nemo/src/io/formats/rdf_triples.rs
+++ b/nemo/src/io/formats/rdf_triples.rs
@@ -13,8 +13,21 @@ use rio_xml::RdfXmlParser;
 
 use crate::{
     builder_proxy::{LogicalAnyColumnBuilderProxy, LogicalColumnBuilderProxy},
-    io::{formats::PROGRESS_NOTIFY_INCREMENT, resource_providers::ResourceProviders},
+    io::{
+        formats::PROGRESS_NOTIFY_INCREMENT,
+        parser::{span_from_str, turtle::numeric_literal},
+        resource_providers::ResourceProviders,
+    },
 };
+
+/// The IRI identifying the XSD integer data type.
+pub const XSD_INTEGER: &str = "<http://www.w3.org/2001/XMLSchema#integer>";
+/// The IRI identifying the XSD decimal data type.
+pub const XSD_DECIMAL: &str = "<http://www.w3.org/2001/XMLSchema#decimal>";
+/// The IRI identifying the XSD double data type.
+pub const XSD_DOUBLE: &str = "<http://www.w3.org/2001/XMLSchema#double>";
+/// The IRI identifying the XSD string data type.
+pub const XSD_STRING: &str = "<http://www.w3.org/2001/XMLSchema#string>";
 
 /// A wrapper around [`String`] signifying that this contains a valid Turtle-encoded RDF term.
 #[derive(Debug, Clone)]
@@ -28,15 +41,25 @@ impl TurtleEncodedRDFTerm {
 
     /// Return a normalized form of the term suitable for storage in an `any` Column.
     pub fn into_normalized_string(self) -> String {
-        const XSD_STRING_LITERAL_SUFFIX: &str = r#""^^<http://www.w3.org/2001/XMLSchema#string>"#;
-
         if self.0.is_empty() {
             r#""""#.to_string()
         } else if self.0.starts_with('<') && self.0.ends_with('>') {
+            // an absolute IRI, strip the angle brackets
             self.0[1..self.0.len() - 1].to_string()
-        } else if self.0.starts_with('"') && self.0.ends_with(XSD_STRING_LITERAL_SUFFIX) {
-            self.0[..(self.0.len() - XSD_STRING_LITERAL_SUFFIX.len()) + 1].to_string()
+        } else if self.0.starts_with('"') && self.0.ends_with(XSD_STRING) {
+            // an XSD string literal, drop the datatype
+            self.0[..(self.0.len() - XSD_STRING.len() - 2)].to_string()
+        } else if self.0.starts_with([
+            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '+', '.',
+        ]) {
+            // some simple numeric literal, convert to a typed literal representation
+            let (remainder, literal) =
+                numeric_literal(span_from_str(&self.0)).expect("is a valid numeric literal");
+            debug_assert!(remainder.is_empty());
+
+            literal.into_rdf_term_literal()
         } else {
+            //
             self.0
         }
     }

--- a/nemo/src/io/formats/rdf_triples.rs
+++ b/nemo/src/io/formats/rdf_triples.rs
@@ -29,6 +29,10 @@ pub const XSD_DOUBLE: &str = "<http://www.w3.org/2001/XMLSchema#double>";
 /// The IRI identifying the XSD string data type.
 pub const XSD_STRING: &str = "<http://www.w3.org/2001/XMLSchema#string>";
 
+pub(crate) const INITIAL_FOR_SIMPLE_NUMERIC_LITERAL: &[char] = &[
+    '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '+', '.',
+];
+
 /// A wrapper around [`String`] signifying that this contains a valid Turtle-encoded RDF term.
 #[derive(Debug, Clone)]
 pub struct TurtleEncodedRDFTerm(String);
@@ -49,9 +53,7 @@ impl TurtleEncodedRDFTerm {
         } else if self.0.starts_with('"') && self.0.ends_with(XSD_STRING) {
             // an XSD string literal, drop the datatype
             self.0[..(self.0.len() - XSD_STRING.len() - 2)].to_string()
-        } else if self.0.starts_with([
-            '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', '-', '+', '.',
-        ]) {
+        } else if self.0.starts_with(INITIAL_FOR_SIMPLE_NUMERIC_LITERAL) {
             // some simple numeric literal, convert to a typed literal representation
             let (remainder, literal) =
                 numeric_literal(span_from_str(&self.0)).expect("is a valid numeric literal");

--- a/nemo/src/io/parser.rs
+++ b/nemo/src/io/parser.rs
@@ -21,7 +21,7 @@ pub(crate) mod iri;
 pub(crate) mod rfc5234;
 pub(crate) mod sparql;
 pub(crate) mod turtle;
-pub use types::{LocatedParseError, ParseError, ParseResult};
+pub use types::{span_from_str, LocatedParseError, ParseError, ParseResult};
 
 /// Parse a program in the given `input`-String and return a [`Program`].
 ///

--- a/nemo/src/io/parser.rs
+++ b/nemo/src/io/parser.rs
@@ -177,7 +177,7 @@ fn resolve_prefixed_rdf_literal(
 }
 
 #[traced("parser")]
-fn parse_bare_name(input: Span<'_>) -> IntermediateResult<Span<'_>> {
+pub(crate) fn parse_bare_name(input: Span<'_>) -> IntermediateResult<Span<'_>> {
     map_error(
         recognize(pair(
             alpha1,

--- a/nemo/src/io/parser/turtle.rs
+++ b/nemo/src/io/parser/turtle.rs
@@ -15,7 +15,7 @@ use crate::model::NumericLiteral;
 use nemo_physical::datatypes::Double;
 
 use super::{
-    map_error, span_from_str,
+    map_error,
     sparql::{iri, Name},
     token,
     types::{IntermediateResult, Span},
@@ -168,14 +168,6 @@ pub fn numeric_literal(input: Span) -> IntermediateResult<NumericLiteral> {
 pub(super) enum RdfLiteral<'a> {
     LanguageString { value: &'a str, tag: &'a str },
     DatatypeValue { value: &'a str, datatype: Name<'a> },
-}
-
-pub(crate) fn is_valid_rdf_literal(input: &str) -> bool {
-    if let Ok((remainder, _)) = rdf_literal(span_from_str(input)) {
-        return remainder.is_empty();
-    }
-
-    false
 }
 
 #[traced("parser::turtle")]

--- a/nemo/src/io/parser/turtle.rs
+++ b/nemo/src/io/parser/turtle.rs
@@ -15,7 +15,7 @@ use crate::model::NumericLiteral;
 use nemo_physical::datatypes::Double;
 
 use super::{
-    map_error,
+    map_error, span_from_str,
     sparql::{iri, Name},
     token,
     types::{IntermediateResult, Span},
@@ -168,6 +168,14 @@ pub fn numeric_literal(input: Span) -> IntermediateResult<NumericLiteral> {
 pub(super) enum RdfLiteral<'a> {
     LanguageString { value: &'a str, tag: &'a str },
     DatatypeValue { value: &'a str, datatype: Name<'a> },
+}
+
+pub(crate) fn is_valid_rdf_literal(input: &str) -> bool {
+    if let Ok((remainder, _)) = rdf_literal(span_from_str(input)) {
+        return remainder.is_empty();
+    }
+
+    false
 }
 
 #[traced("parser::turtle")]

--- a/nemo/src/io/parser/types.rs
+++ b/nemo/src/io/parser/types.rs
@@ -12,6 +12,11 @@ use crate::model::PrimitiveType;
 /// A [`LocatedSpan`] over the input.
 pub(super) type Span<'a> = LocatedSpan<&'a str>;
 
+/// Create a [`Span`][nom_locate::LocatedSpan] over the input.
+pub fn span_from_str(input: &str) -> Span<'_> {
+    Span::new(input)
+}
+
 /// An intermediate parsing result
 pub(super) type IntermediateResult<'a, T> = IResult<Span<'a>, T, LocatedParseError>;
 

--- a/nemo/src/model/rule_model/term.rs
+++ b/nemo/src/model/rule_model/term.rs
@@ -3,7 +3,10 @@ use std::path::PathBuf;
 use nemo_physical::datatypes::Double;
 use sanitise_file_name::{sanitise_with_options, Options};
 
-use crate::model::TypeConstraint;
+use crate::{
+    io::formats::rdf_triples::{XSD_DECIMAL, XSD_DOUBLE, XSD_INTEGER},
+    model::TypeConstraint,
+};
 
 /// An identifier for, e.g., a Term or a Predicate.
 #[derive(Debug, Eq, PartialEq, Hash, Clone, PartialOrd, Ord)]
@@ -143,6 +146,19 @@ pub enum NumericLiteral {
     Decimal(i64, u64),
     /// A double literal.
     Double(Double),
+}
+
+impl NumericLiteral {
+    /// Converts to an RDF literal lexical representation suitable for, e.g., N-Triples.
+    pub fn into_rdf_term_literal(self) -> String {
+        match self {
+            NumericLiteral::Integer(value) => format!(r#""{value}"^^{XSD_INTEGER}"#).to_string(),
+            NumericLiteral::Decimal(whole, fraction) => {
+                format!(r#""{whole}.{fraction}"^^{XSD_DECIMAL}"#).to_string()
+            }
+            NumericLiteral::Double(value) => format!(r#""{value}"^^{XSD_DOUBLE}"#).to_string(),
+        }
+    }
 }
 
 impl std::fmt::Display for NumericLiteral {


### PR DESCRIPTION
For RDF-based formats, we are currently performing a redundant revalidation that the parsed terms are actually valid encodings of RDF literals. However, we already know that they are (since they were parsed successfully). This skips this validation, leading to significantly faster loading times.

For DSV files, we do not know already if the contents of a column are valid encodings of RDF files, so we optimistically try to parse those as objects in a single Turtle triple – if it succeeds, it is a valid term, and we can proceed as above, otherwise, we already know it's not valid, so it can only be an un-bracketed IRI or it needs quoting.