### PR TITLE
use flate2::read::MultiGzDecoder instead of flate2::read::GzDecoder

### DIFF
--- a/nemo/src/io/resource_providers.rs
+++ b/nemo/src/io/resource_providers.rs
@@ -2,7 +2,7 @@
 
 use std::{io::Read, rc::Rc};
 
-use flate2::read::GzDecoder;
+use flate2::read::MultiGzDecoder;
 
 use crate::io::parser::{all_input_consumed, iri::iri};
 use nemo_physical::{error::ReadingError, table_reader::Resource};
@@ -63,7 +63,7 @@ impl ResourceProviders {
                 }
 
                 // Try opening with gzip
-                let gz_reader = GzDecoder::new(reader);
+                let gz_reader = MultiGzDecoder::new(reader);
 
                 if gz_reader.header().is_some() {
                     return Ok(Box::new(gz_reader));


### PR DESCRIPTION
In simple words, `GzDecoder` decodes the fist member of a Reader while `MultiGzDecoder` decodes all of them.

From documentation:
```
A gzip member consists of a header, compressed data and a trailer.
The gzip specification, however, allows multiple gzip members to be
joined in a single stream. MultiGzDecoder will decode all consecutive
members while GzDecoder will only decompress the first gzip member.
```

Hence, in this pull request I suggest to use `MultiGzDecoder` instead of `GzDecoder`

More information [here](https://docs.rs/flate2/latest/flate2/read/struct.MultiGzDecoder.html)