### PR TITLE
Correctly handle pointless decimal literals

### DIFF
--- a/nemo/src/builder_proxy.rs
+++ b/nemo/src/builder_proxy.rs
@@ -499,6 +499,28 @@ mod test {
             value: "1.23".to_string(),
             datatype: "http://www.w3.org/2001/XMLSchema#decimal".to_string(),
         });
+        let signed_decimal_datavalue_literal = Term::RdfLiteral(RdfLiteral::DatatypeValue {
+            value: "+1.23".to_string(),
+            datatype: "http://www.w3.org/2001/XMLSchema#decimal".to_string(),
+        });
+        let negative_decimal_datavalue_literal = Term::RdfLiteral(RdfLiteral::DatatypeValue {
+            value: "-1.23".to_string(),
+            datatype: "http://www.w3.org/2001/XMLSchema#decimal".to_string(),
+        });
+        let pointless_decimal_datavalue_literal = Term::RdfLiteral(RdfLiteral::DatatypeValue {
+            value: "23".to_string(),
+            datatype: "http://www.w3.org/2001/XMLSchema#decimal".to_string(),
+        });
+        let signed_pointless_decimal_datavalue_literal =
+            Term::RdfLiteral(RdfLiteral::DatatypeValue {
+                value: "+23".to_string(),
+                datatype: "http://www.w3.org/2001/XMLSchema#decimal".to_string(),
+            });
+        let negative_pointless_decimal_datavalue_literal =
+            Term::RdfLiteral(RdfLiteral::DatatypeValue {
+                value: "-23".to_string(),
+                datatype: "http://www.w3.org/2001/XMLSchema#decimal".to_string(),
+            });
         let double_datavalue_literal = Term::RdfLiteral(RdfLiteral::DatatypeValue {
             value: "3.33".to_string(),
             datatype: "http://www.w3.org/2001/XMLSchema#double".to_string(),
@@ -562,6 +584,15 @@ mod test {
         integer_lbp.add(integer_datavalue_literal).unwrap();
 
         any_lbp.add(decimal_datavalue_literal).unwrap();
+        any_lbp.add(signed_decimal_datavalue_literal).unwrap();
+        any_lbp.add(negative_decimal_datavalue_literal).unwrap();
+        any_lbp.add(pointless_decimal_datavalue_literal).unwrap();
+        any_lbp
+            .add(signed_pointless_decimal_datavalue_literal)
+            .unwrap();
+        any_lbp
+            .add(negative_pointless_decimal_datavalue_literal)
+            .unwrap();
 
         any_lbp.add(double_datavalue_literal.clone()).unwrap();
         double_lbp.add(double_datavalue_literal).unwrap();
@@ -602,6 +633,11 @@ mod test {
             "STRING:string datavalue",
             "INTEGER:73",
             "DECIMAL:1.23",
+            "DECIMAL:1.23",
+            "DECIMAL:-1.23",
+            "DECIMAL:23.0",
+            "DECIMAL:23.0",
+            "DECIMAL:-23.0",
             "DOUBLE:3.33",
         ].into_iter().map(String::from).collect::<Vec<_>>());
 

--- a/nemo/src/model/types/primitive_logical_value.rs
+++ b/nemo/src/model/types/primitive_logical_value.rs
@@ -347,6 +347,7 @@ impl TryFrom<Term> for PhysicalString {
                         let (a, b) = value
                             .rsplit_once('.')
                             .and_then(|(a, b)| Some((a.parse().ok()?, b.parse().ok()?)))
+                            .or_else(|| Some((value.parse().ok()?, 0)))
                             .ok_or(InvalidRuleTermConversion::new(term, PrimitiveType::Any))?;
 
                         Ok(Decimal(a, b).into())
@@ -683,6 +684,28 @@ mod test {
             value: "1.23".to_string(),
             datatype: XSD_DECIMAL.to_string(),
         });
+        let signed_decimal_datavalue_literal = Term::RdfLiteral(RdfLiteral::DatatypeValue {
+            value: "+1.23".to_string(),
+            datatype: XSD_DECIMAL.to_string(),
+        });
+        let negative_decimal_datavalue_literal = Term::RdfLiteral(RdfLiteral::DatatypeValue {
+            value: "-1.23".to_string(),
+            datatype: XSD_DECIMAL.to_string(),
+        });
+        let pointless_decimal_datavalue_literal = Term::RdfLiteral(RdfLiteral::DatatypeValue {
+            value: "23".to_string(),
+            datatype: XSD_DECIMAL.to_string(),
+        });
+        let signed_pointless_decimal_datavalue_literal =
+            Term::RdfLiteral(RdfLiteral::DatatypeValue {
+                value: "+23".to_string(),
+                datatype: XSD_DECIMAL.to_string(),
+            });
+        let negative_pointless_decimal_datavalue_literal =
+            Term::RdfLiteral(RdfLiteral::DatatypeValue {
+                value: "-23".to_string(),
+                datatype: XSD_DECIMAL.to_string(),
+            });
         let double_datavalue_literal = Term::RdfLiteral(RdfLiteral::DatatypeValue {
             value: "3.33".to_string(),
             datatype: XSD_DOUBLE.to_string(),
@@ -706,6 +729,16 @@ mod test {
             format!("{INTEGER_PREFIX}73").into();
         let expected_decimal_datavalue_literal: PhysicalString =
             format!("{DECIMAL_PREFIX}1.23").into();
+        let expected_signed_decimal_datavalue_literal: PhysicalString =
+            format!("{DECIMAL_PREFIX}1.23").into();
+        let expected_negative_decimal_datavalue_literal: PhysicalString =
+            format!("{DECIMAL_PREFIX}-1.23").into();
+        let expected_pointless_decimal_datavalue_literal: PhysicalString =
+            format!("{DECIMAL_PREFIX}23.0").into();
+        let expected_signed_pointless_decimal_datavalue_literal: PhysicalString =
+            format!("{DECIMAL_PREFIX}23.0").into();
+        let expected_negative_pointless_decimal_datavalue_literal: PhysicalString =
+            format!("{DECIMAL_PREFIX}-23.0").into();
         let expected_double_datavalue_literal: PhysicalString =
             format!("{DOUBLE_PREFIX}3.33").into();
 
@@ -769,6 +802,26 @@ mod test {
         assert_eq!(
             PhysicalString::try_from(decimal_datavalue_literal).unwrap(),
             expected_decimal_datavalue_literal
+        );
+        assert_eq!(
+            PhysicalString::try_from(signed_decimal_datavalue_literal).unwrap(),
+            expected_signed_decimal_datavalue_literal
+        );
+        assert_eq!(
+            PhysicalString::try_from(negative_decimal_datavalue_literal).unwrap(),
+            expected_negative_decimal_datavalue_literal
+        );
+        assert_eq!(
+            PhysicalString::try_from(pointless_decimal_datavalue_literal).unwrap(),
+            expected_pointless_decimal_datavalue_literal
+        );
+        assert_eq!(
+            PhysicalString::try_from(signed_pointless_decimal_datavalue_literal).unwrap(),
+            expected_signed_pointless_decimal_datavalue_literal
+        );
+        assert_eq!(
+            PhysicalString::try_from(negative_pointless_decimal_datavalue_literal).unwrap(),
+            expected_negative_pointless_decimal_datavalue_literal
         );
         assert_eq!(
             PhysicalString::try_from(double_datavalue_literal.clone()).unwrap(),


### PR DESCRIPTION
Decimal literals can omit the decimal point if the fractional part is zero. This was not handled before, leading to literals wrongly ignored as malformed. Since such pointless decimal literals are also precisely [valid integer literals](https://www.w3.org/TR/xmlschema11-2/#integer), this also adds the necessary conversions.