### PR TITLE
Shrink columns on construction

### DIFF
--- a/nemo-physical/src/columnar/column_types/rle.rs
+++ b/nemo-physical/src/columnar/column_types/rle.rs
@@ -164,6 +164,10 @@ where
             increments.push(e.increment);
         });
 
+        values.shrink_to_fit();
+        end_indices.shrink_to_fit();
+        increments.shrink_to_fit();
+
         ColumnRle {
             values,
             end_indices,

--- a/nemo-physical/src/columnar/column_types/vector.rs
+++ b/nemo-physical/src/columnar/column_types/vector.rs
@@ -20,6 +20,9 @@ pub struct ColumnVector<T> {
 impl<T: Debug + Copy + Ord> ColumnVector<T> {
     /// Constructs a new ColumnVector from a vector of the suitable type.
     pub fn new(data: Vec<T>) -> ColumnVector<T> {
+        let mut data = data;
+        data.shrink_to_fit();
+
         ColumnVector { data }
     }
 }


### PR DESCRIPTION
Columns are immutable, so once constructed, we will never need to add more elements to them. Thus, shrink them to size to avoid wasting space. On a sample of Wikidata with 10 million triples, this brings memory usage down from 4.2 GiB to 2.9 GiB.