### PR TITLE
Feature/129 predicate memory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1636,7 +1636,9 @@ dependencies = [
 name = "nemo"
 version = "0.3.1-dev"
 dependencies = [
+ "ascii_tree",
  "assert_fs",
+ "bytesize",
  "csv",
  "env_logger 0.10.0",
  "flate2",

--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -125,6 +125,9 @@ pub struct CliApp {
     /// Display detailed timing information
     #[arg(long = "detailed-timing", default_value = "false")]
     pub detailed_timing: bool,
+    /// Display detailed memory information
+    #[arg(long = "detailed-memory", default_value = "false")]
+    pub detailed_memory: bool,
     /// Specify directory for input files.
     #[arg(short = 'I', long = "input-dir")]
     pub input_directory: Option<PathBuf>,

--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -182,6 +182,10 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
         );
     }
 
+    if cli.detailed_memory {
+        println!("\n{}", engine.memory_usage());
+    }
+
     Ok(())
 }
 

--- a/nemo/Cargo.toml
+++ b/nemo/Cargo.toml
@@ -39,6 +39,8 @@ oxiri = "0.2.2"
 tokio = { version = "1.29.1", features = [ "rt" ] }
 reqwest = { version = "0.11.18" }
 num = "0.4.0"
+bytesize = "1.2"
+ascii_tree = "0.1.1"
 
 [dev-dependencies]
 env_logger = "*"

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -16,7 +16,7 @@ use crate::{
         Identifier, Program, TermOperation,
     },
     program_analysis::analysis::ProgramAnalysis,
-    table_manager::TableManager,
+    table_manager::{MemoryUsage, TableManager},
 };
 
 use super::{rule_execution::RuleExecution, selection_strategy::strategy::RuleSelectionStrategy};
@@ -373,5 +373,10 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
         }
 
         result
+    }
+
+    /// Return the [`MemoryUsage`] of the tables used by the chase.
+    pub fn memory_usage(&self) -> MemoryUsage {
+        self.table_manager.memory_usage()
     }
 }

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -375,7 +375,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
         result
     }
 
-    /// Return the [`MemoryUsage`] of the tables used by the chase.
+    /// Return the amount of consumed memory for the tables used by the chase.
     pub fn memory_usage(&self) -> MemoryUsage {
         self.table_manager.memory_usage()
     }


### PR DESCRIPTION
Adds the command line option `detailed-memory` which, if enabled, prints out an ascii_tree showing the memory consumption of each predicate. 

This does not account for temporary tables created during the evaluation of a rule and does not consider other objects that might contribute to the memory footprint like the dictionary.

Closes #129 .
