### PR TITLE
Implement Tracing

### DIFF
--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -131,4 +131,7 @@ pub struct CliApp {
     /// Specify directory for input files.
     #[arg(short = 'I', long = "input-dir")]
     pub input_directory: Option<PathBuf>,
+    /// Specify a fact, the origin of which should be explained
+    #[arg(long = "trace", default_value = "None")]
+    pub trace_fact: Option<String>
 }

--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -132,6 +132,6 @@ pub struct CliApp {
     #[arg(short = 'I', long = "input-dir")]
     pub input_directory: Option<PathBuf>,
     /// Specify a fact, the origin of which should be explained
-    #[arg(long = "trace", default_value = "None")]
-    pub trace_fact: Option<String>
+    #[arg(long = "trace")]
+    pub trace_fact: Option<String>,
 }

--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -197,7 +197,7 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
     }
 
     if let Some(fact) = parsed_fact {
-        if let Some(trace) = engine.trace(fact.clone()) {
+        if let Some(trace) = engine.trace(fact.clone())? {
             println!("\n{trace}");
         } else {
             println!("{fact} was not derived");

--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -117,11 +117,7 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
     log::info!("Rules parsed");
     log::trace!("{:?}", program);
 
-    let parsed_fact = if let Some(fact_string) = cli.trace_fact {
-        Some(parse_fact(fact_string)?)
-    } else {
-        None
-    };
+    let parsed_fact = cli.trace_fact.map(parse_fact).transpose()?;
 
     if cli.write_all_idb_predicates {
         program.force_output_predicate_selection(OutputPredicateSelection::AllIDBPredicates)

--- a/nemo-physical/src/datatypes/storage_value.rs
+++ b/nemo-physical/src/datatypes/storage_value.rs
@@ -50,6 +50,23 @@ impl StorageValueT {
             Self::Double(_) => StorageTypeName::Double,
         }
     }
+
+    /// Create an iterator over the single storage element.
+    pub fn iter_once(&self) -> StorageValueIteratorT {
+        macro_rules! to_iterator_for_type {
+            ($variant:ident, $value:ident) => {{
+                StorageValueIteratorT::$variant(Box::new(std::iter::once(*$value)))
+            }};
+        }
+
+        match self {
+            StorageValueT::U32(value) => to_iterator_for_type!(U32, value),
+            StorageValueT::U64(value) => to_iterator_for_type!(U64, value),
+            StorageValueT::I64(value) => to_iterator_for_type!(I64, value),
+            StorageValueT::Float(value) => to_iterator_for_type!(Float, value),
+            StorageValueT::Double(value) => to_iterator_for_type!(Double, value),
+        }
+    }
 }
 
 macro_rules! storage_value_try_into {

--- a/nemo-physical/src/management/database.rs
+++ b/nemo-physical/src/management/database.rs
@@ -893,7 +893,7 @@ impl DatabaseInstance {
         Ok(permanent_ids)
     }
 
-    /// Execute a given [`SubtableExecutionPlan`]
+    /// Execute a given [`ExecutionPlan`]
     /// but evaluate it only until the first row of the result table
     /// or return `None` if it is empty.
     /// The result table is considered to be the (unique) table marked as permanent output.

--- a/nemo-physical/src/management/execution_plan.rs
+++ b/nemo-physical/src/management/execution_plan.rs
@@ -445,8 +445,13 @@ impl ExecutionPlan {
         }
     }
 
+    /// Deletes all information which marks execution nodes as output.
+    pub fn clear_write_nodes(&mut self) {
+        self.out_nodes.clear();
+    }
+
     /// Return a list of [`ExecutionTree`] that are derived taking the subgraph at each write node.
-    /// Each tree will be associated with an id that corrsponds to the id of
+    /// Each tree will be associated with an id that corresponds to the id of
     /// the write node from which the tree is derived.
     pub(super) fn split_at_write_nodes(&self) -> Vec<(usize, ExecutionTree)> {
         let write_node_ids: HashSet<usize> = self.out_nodes.iter().map(|o| o.node.id()).collect();

--- a/nemo-physical/src/tabular/operations/materialize.rs
+++ b/nemo-physical/src/tabular/operations/materialize.rs
@@ -77,7 +77,7 @@ pub fn materialize(trie_scan: &mut impl TrieScan) -> Option<Trie> {
 
 /// Tests whether an iterator is empty by materializing it until the first element.
 /// Returns the first row of the result or `None` if it is empty.
-pub fn scan_is_empty(trie_scan: &mut impl TrieScan) -> Option<TableRow> {
+pub fn scan_first_match(trie_scan: &mut impl TrieScan) -> Option<TableRow> {
     if trie_scan.column_types().is_empty() {
         return None;
     }
@@ -97,7 +97,7 @@ mod test {
     use super::materialize;
     use crate::columnar::traits::column::Column;
     use crate::datatypes::StorageValueT;
-    use crate::tabular::operations::materialize::scan_is_empty;
+    use crate::tabular::operations::materialize::scan_first_match;
     use crate::tabular::operations::{JoinBindings, TrieScanJoin, TrieScanPrune};
     use crate::tabular::table_types::trie::{Trie, TrieScanGeneric};
     use crate::tabular::traits::partial_trie_scan::TrieScanEnum;
@@ -259,7 +259,7 @@ mod test {
             &JoinBindings::new(vec![vec![0, 1], vec![1, 2]]),
         );
 
-        let first_result = scan_is_empty(&mut TrieScanPrune::new(TrieScanEnum::TrieScanJoin(
+        let first_result = scan_first_match(&mut TrieScanPrune::new(TrieScanEnum::TrieScanJoin(
             join_iter,
         )))
         .unwrap();

--- a/nemo-physical/src/tabular/operations/materialize.rs
+++ b/nemo-physical/src/tabular/operations/materialize.rs
@@ -78,7 +78,7 @@ pub fn materialize(trie_scan: &mut impl TrieScan) -> Option<Trie> {
 /// Tests whether an iterator is empty by materializing it until the first element.
 /// Returns the first row of the result or `None` if it is empty.
 pub fn scan_is_empty(trie_scan: &mut impl TrieScan) -> Option<TableRow> {
-    if trie_scan.column_types().len() == 0 {
+    if trie_scan.column_types().is_empty() {
         return None;
     }
 

--- a/nemo-physical/src/tabular/table_types/trie.rs
+++ b/nemo-physical/src/tabular/table_types/trie.rs
@@ -466,19 +466,22 @@ impl Table for Trie {
         debug_assert!(self.columns.len() == row.len());
 
         let mut trie_scan = self.scan();
-        trie_scan.down();
 
         for entry in row {
+            trie_scan.down();
+
             macro_rules! seek_for_datatype {
                 ($variant:ident, $entry:ident) => {
                     if let ColumnScanT::$variant(column_scan) =
                         trie_scan.current_scan().expect("We called down")
                     {
-                        if column_scan.seek($entry).is_none() {
+                        if let Some(closest) = column_scan.seek($entry) {
+                            if closest != $entry {
+                                return false;
+                            }
+                        } else {
                             return false;
                         }
-
-                        trie_scan.down();
                     }
                 };
             }

--- a/nemo-physical/src/tabular/traits/table.rs
+++ b/nemo-physical/src/tabular/traits/table.rs
@@ -1,17 +1,23 @@
 use crate::datatypes::{storage_value::VecT, StorageTypeName, StorageValueT};
 use std::fmt::Debug;
 
+/// A row in a table
+pub type TableRow = Vec<StorageValueT>;
+
 /// Table that stores a relation.
 pub trait Table: Debug {
     /// Build table from a list of columns.
     fn from_cols(cols: Vec<VecT>) -> Self;
 
     /// Build table from a list of rows.
-    fn from_rows(rows: &[Vec<StorageValueT>]) -> Self;
+    fn from_rows(rows: &[TableRow]) -> Self;
 
     /// Returns the number of rows in the table.
     fn row_num(&self) -> usize;
 
     /// Returns the schema of the table.
     fn get_types(&self) -> &Vec<StorageTypeName>;
+
+    /// Returns whether this table contains the given row.
+    fn contains_row(&self, row: TableRow) -> bool;
 }

--- a/nemo/src/error.rs
+++ b/nemo/src/error.rs
@@ -16,6 +16,11 @@ pub use nemo_physical::error::ReadingError;
 #[allow(variant_size_differences)]
 #[derive(Error, Debug)]
 pub enum Error {
+    /// Currently tracing doesn't work for all language features
+    #[error(
+        "Tracing is currently not supported for rules with arithmetic operations in the head."
+    )]
+    TraceUnsupportedFeature(),
     /// Error which implies a needed Rollback
     #[error("Rollback due to csv-error")]
     Rollback(usize),

--- a/nemo/src/execution.rs
+++ b/nemo/src/execution.rs
@@ -10,10 +10,9 @@ use self::selection_strategy::{
 };
 
 pub mod planning;
-
 pub mod rule_execution;
-
 pub mod selection_strategy;
+pub mod tracing;
 
 /// The default strategy that will be used for reasoning
 pub type DefaultExecutionStrategy = StrategyStratifiedNegation<

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -498,7 +498,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
             }
 
             if !compatible {
-                // Fact could not haven unified
+                // Fact could not have been unified
                 continue;
             }
 

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -467,35 +467,33 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                         compatible = false;
                         break;
                     }
-                } else {
-                    if let Term::Variable(variable) = head_term {
-                        // Matching with existential variables should not produce any restrictions,
-                        // so we just consider universal variables here
-                        if variable.is_existential() {
-                            continue;
-                        }
-
-                        if rule.constructors().contains_key(variable) {
-                            // TODO: Support arbitrary operations in the head
-                            return Err(Error::TraceUnsupportedFeature());
-                        }
-
-                        match assignment.entry(variable.clone()) {
-                            Entry::Occupied(entry) => {
-                                if ty.ground_term_to_data_value_t(entry.get().clone())
-                                    != ty.ground_term_to_data_value_t(fact_term.clone())
-                                {
-                                    compatible = false;
-                                    break;
-                                }
-                            }
-                            Entry::Vacant(entry) => {
-                                entry.insert(fact_term.clone());
-                            }
-                        }
-                    } else {
-                        unreachable!("Variables are the only non-ground terms");
+                } else if let Term::Variable(variable) = head_term {
+                    // Matching with existential variables should not produce any restrictions,
+                    // so we just consider universal variables here
+                    if variable.is_existential() {
+                        continue;
                     }
+
+                    if rule.constructors().contains_key(variable) {
+                        // TODO: Support arbitrary operations in the head
+                        return Err(Error::TraceUnsupportedFeature());
+                    }
+
+                    match assignment.entry(variable.clone()) {
+                        Entry::Occupied(entry) => {
+                            if ty.ground_term_to_data_value_t(entry.get().clone())
+                                != ty.ground_term_to_data_value_t(fact_term.clone())
+                            {
+                                compatible = false;
+                                break;
+                            }
+                        }
+                        Entry::Vacant(entry) => {
+                            entry.insert(fact_term.clone());
+                        }
+                    }
+                } else {
+                    unreachable!("Variables are the only non-ground terms");
                 }
             }
 

--- a/nemo/src/execution/tracing.rs
+++ b/nemo/src/execution/tracing.rs
@@ -1,0 +1,3 @@
+//! This module contains functionality for keeping track of the origings of derived facts
+
+pub mod trace;

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -44,17 +44,17 @@ pub enum ExecutionTrace {
 }
 
 impl ExecutionTrace {
-    /// Create a new leaf node in an [`ExecutionTree`].
+    /// Create a new leaf node in an [`ExecutionTrace`].
     pub fn leaf(fact: Atom) -> Self {
         ExecutionTrace::Fact(fact)
     }
 
-    /// Create a new node in an [`ExecutionTree`].
+    /// Create a new node in an [`ExecutionTrace`].
     pub fn node(rule_position: RuleApplication, subtraces: Vec<ExecutionTrace>) -> Self {
         ExecutionTrace::Rule(rule_position, subtraces)
     }
 
-    /// Create an [`acii_tree::Tree`] representation.
+    /// Create an ascii tree representation.
     pub fn ascii_tree(&self) -> ascii_tree::Tree {
         match self {
             ExecutionTrace::Fact(fact) => ascii_tree::Tree::Leaf(vec![fact.to_string()]),

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -1,0 +1,82 @@
+//! This module contains basic data structures for tracing the origins of derived facts.
+
+use std::collections::HashMap;
+
+use crate::model::{Atom, Rule, Term, Variable};
+
+/// Identifies an atom within the head of a rule
+#[derive(Debug)]
+struct RulePosition {
+    rule: Rule,
+    position: usize,
+}
+
+impl RulePosition {
+    /// Create new [`RulePosition`].
+    pub fn new(rule: Rule, position: usize) -> Self {
+        debug_assert!(position < rule.head().len());
+
+        Self { rule, position }
+    }
+}
+
+impl std::fmt::Display for RulePosition {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.rule.fmt(f)
+    }
+}
+
+#[derive(Debug)]
+enum FactOrigin {
+    /// Fact was derived from the given rule
+    Rule(RulePosition),
+    /// Fact was given as input
+    Fact(Atom),
+}
+
+impl std::fmt::Display for FactOrigin {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FactOrigin::Rule(rule) => rule.fmt(f),
+            FactOrigin::Fact(fact) => fact.fmt(f),
+        }
+    }
+}
+
+/// Represents the derivation tree for one derived fact
+#[derive(Debug)]
+pub struct ExecutionTrace {
+    origin: FactOrigin,
+
+    subtraces: Vec<ExecutionTrace>,
+}
+
+impl ExecutionTrace {
+    /// Create a new leaf node in an [`ExecutionTree`].
+    pub fn leaf(origin: FactOrigin) -> Self {
+        ExecutionTrace {
+            origin,
+            subtraces: Vec::default(),
+        }
+    }
+
+    /// Create a new node in an [`ExecutionTree`].
+    pub fn node(origin: FactOrigin, subtraces: Vec<ExecutionTrace>) -> Self {
+        ExecutionTrace { origin, subtraces }
+    }
+
+    fn assign_variables(rule: &Rule, assignment: &VariableAssignment) -> Rule {
+        todo!()
+    }
+
+    // fn ascii_tree_recursive()
+
+    pub fn ascii_tree(&self) -> ascii_tree::Tree {
+        if self.subtraces.is_empty() {
+            ascii_tree::Tree::Leaf(vec![])
+        }
+    }
+}
+
+#[derive(Debug)]
+struct VariableAssignment(HashMap<Variable, Term>);

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -2,21 +2,23 @@
 
 use std::collections::HashMap;
 
+use ascii_tree::write_tree;
+
 use crate::model::{Atom, Rule, Term, Variable};
 
 /// Identifies an atom within the head of a rule
 #[derive(Debug)]
-struct RulePosition {
+pub struct RulePosition {
     rule: Rule,
-    position: usize,
+    _position: usize,
 }
 
 impl RulePosition {
     /// Create new [`RulePosition`].
-    pub fn new(rule: Rule, position: usize) -> Self {
-        debug_assert!(position < rule.head().len());
+    pub fn new(rule: Rule, _position: usize) -> Self {
+        debug_assert!(_position < rule.head().len());
 
-        Self { rule, position }
+        Self { rule, _position }
     }
 }
 
@@ -26,57 +28,144 @@ impl std::fmt::Display for RulePosition {
     }
 }
 
-#[derive(Debug)]
-enum FactOrigin {
-    /// Fact was derived from the given rule
-    Rule(RulePosition),
-    /// Fact was given as input
-    Fact(Atom),
-}
-
-impl std::fmt::Display for FactOrigin {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            FactOrigin::Rule(rule) => rule.fmt(f),
-            FactOrigin::Fact(fact) => fact.fmt(f),
-        }
-    }
-}
-
 /// Represents the derivation tree for one derived fact
 #[derive(Debug)]
-pub struct ExecutionTrace {
-    origin: FactOrigin,
-
-    subtraces: Vec<ExecutionTrace>,
+pub enum ExecutionTrace {
+    /// Fact was given as input
+    Fact(Atom),
+    /// Fact was derived from the given rule
+    Rule(RulePosition, Vec<ExecutionTrace>),
 }
 
 impl ExecutionTrace {
     /// Create a new leaf node in an [`ExecutionTree`].
-    pub fn leaf(origin: FactOrigin) -> Self {
-        ExecutionTrace {
-            origin,
-            subtraces: Vec::default(),
-        }
+    pub fn leaf(fact: Atom) -> Self {
+        ExecutionTrace::Fact(fact)
     }
 
     /// Create a new node in an [`ExecutionTree`].
-    pub fn node(origin: FactOrigin, subtraces: Vec<ExecutionTrace>) -> Self {
-        ExecutionTrace { origin, subtraces }
+    pub fn node(rule_position: RulePosition, subtraces: Vec<ExecutionTrace>) -> Self {
+        ExecutionTrace::Rule(rule_position, subtraces)
     }
 
-    fn assign_variables(rule: &Rule, assignment: &VariableAssignment) -> Rule {
-        todo!()
-    }
-
-    // fn ascii_tree_recursive()
-
+    /// Create an [`acii_tree::Tree`] representation.
     pub fn ascii_tree(&self) -> ascii_tree::Tree {
-        if self.subtraces.is_empty() {
-            ascii_tree::Tree::Leaf(vec![])
+        match self {
+            ExecutionTrace::Fact(fact) => ascii_tree::Tree::Leaf(vec![fact.to_string()]),
+            ExecutionTrace::Rule(rule, subtraces) => {
+                let subtrees = subtraces.iter().map(|t| t.ascii_tree()).collect();
+                ascii_tree::Tree::Node(rule.to_string(), subtrees)
+            }
         }
+    }
+}
+
+impl std::fmt::Display for ExecutionTrace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write_tree(f, &self.ascii_tree())
     }
 }
 
 #[derive(Debug)]
 struct VariableAssignment(HashMap<Variable, Term>);
+
+impl VariableAssignment {
+    pub fn apply(&self, mut rule: Rule) -> Rule {
+        for (variable, term) in &self.0 {
+            rule.replace_term(&Term::Variable(variable.clone()), term);
+        }
+
+        rule
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use crate::model::{Atom, Identifier, Literal, Rule, Term, TermTree, Variable};
+
+    use super::{ExecutionTrace, RulePosition};
+
+    #[test]
+    fn print_trace() {
+        // P(b, a) :- Q(a, b) .
+        let rule_1 = Rule::new(
+            vec![Atom::new(
+                Identifier("P".to_string()),
+                vec![
+                    TermTree::leaf(Term::Constant(Identifier("b".to_string()))),
+                    TermTree::leaf(Term::Constant(Identifier("a".to_string()))),
+                ],
+            )],
+            vec![Literal::Positive(Atom::new(
+                Identifier("Q".to_string()),
+                vec![
+                    TermTree::leaf(Term::Constant(Identifier("a".to_string()))),
+                    TermTree::leaf(Term::Constant(Identifier("b".to_string()))),
+                ],
+            ))],
+            vec![],
+        );
+        // S(a) :- T(a) .
+        let rule_2 = Rule::new(
+            vec![Atom::new(
+                Identifier("S".to_string()),
+                vec![TermTree::leaf(Term::Variable(Variable::Universal(
+                    Identifier("a".to_string()),
+                )))],
+            )],
+            vec![Literal::Positive(Atoxm::new(
+                Identifier("T".to_string()),
+                vec![TermTree::leaf(Term::Variable(Variable::Universal(
+                    Identifier("a".to_string()),
+                )))],
+            ))],
+            vec![],
+        );
+        // R(b, a) :- P(b, a), S(a) .
+        let rule_3 = Rule::new(
+            vec![Atom::new(
+                Identifier("R".to_string()),
+                vec![
+                    TermTree::leaf(Term::Variable(Variable::Universal(Identifier(
+                        "b".to_string(),
+                    )))),
+                    TermTree::leaf(Term::Variable(Variable::Universal(Identifier(
+                        "a".to_string(),
+                    )))),
+                ],
+            )],
+            vec![
+                Literal::Positive(Atom::new(
+                    Identifier("P".to_string()),
+                    vec![
+                        TermTree::leaf(Term::Constant(Identifier("b".to_string()))),
+                        TermTree::leaf(Term::Constant(Identifier("a".to_string()))),
+                    ],
+                )),
+                Literal::Positive(Atom::new(
+                    Identifier("S".to_string()),
+                    vec![TermTree::leaf(Term::Constant(Identifier("a".to_string())))],
+                )),
+            ],
+            vec![],
+        );
+
+        let q_ab = Atom::new(
+            Identifier("Q".to_string()),
+            vec![
+                TermTree::leaf(Term::Constant(Identifier("a".to_string()))),
+                TermTree::leaf(Term::Constant(Identifier("b".to_string()))),
+            ],
+        );
+
+        let s_a = Atom::new(
+            Identifier("S".to_string()),
+            vec![TermTree::leaf(Term::Constant(Identifier("a".to_string())))],
+        );
+
+        let trace = ExecutionTrace::node(RulePosition::new(rule_3, 0), vec![ExecutionTrace::node(Rule)]) 
+        
+        // ExecutionTrace::leaf(q_ab);
+
+    }
+}

--- a/nemo/src/io/parser.rs
+++ b/nemo/src/io/parser.rs
@@ -35,6 +35,18 @@ pub fn parse_program(input: impl AsRef<str>) -> Result<Program, Error> {
     Ok(program)
 }
 
+/// Parse a single fact in the given `input`-String and return a [`Program`].
+///
+/// The program will be parsed and checked for unsupported features.
+///
+/// # Error
+/// Returns an appropriate [`Error`] variant on parsing and feature check issues.
+pub fn parse_fact(mut input: String) -> Result<Fact, Error> {
+    input += ".";
+    let fact = all_input_consumed(RuleParser::new().parse_fact())(input.as_str())?;
+    Ok(fact)
+}
+
 /// A combinator to add tracing to the parser.
 /// [fun] is an identifier for the parser and [parser] is the actual parser.
 #[inline(always)]

--- a/nemo/src/model.rs
+++ b/nemo/src/model.rs
@@ -13,3 +13,7 @@ pub mod types;
 pub use rule_model::*;
 pub use types::complex_types::*;
 pub use types::primitive_types::PrimitiveType;
+
+use std::collections::HashMap;
+/// Map from variables to terms
+pub type VariableAssignment = HashMap<Variable, Term>;

--- a/nemo/src/model/chase_model/atom.rs
+++ b/nemo/src/model/chase_model/atom.rs
@@ -128,7 +128,7 @@ impl std::fmt::Display for ChaseAtom {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         self.predicate.fmt(f)?;
         f.write_str("(")?;
-        for (index, term) in self.terms().into_iter().enumerate() {
+        for (index, term) in self.terms().iter().enumerate() {
             term.fmt(f)?;
             if index < self.terms.len() - 1 {
                 f.write_str(", ")?;

--- a/nemo/src/model/chase_model/atom.rs
+++ b/nemo/src/model/chase_model/atom.rs
@@ -123,3 +123,17 @@ impl ChaseAtom {
         }
     }
 }
+
+impl std::fmt::Display for ChaseAtom {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.predicate.fmt(f)?;
+        f.write_str("(")?;
+        for (index, term) in self.terms().into_iter().enumerate() {
+            term.fmt(f)?;
+            if index < self.terms.len() - 1 {
+                f.write_str(", ")?;
+            }
+        }
+        f.write_str(")")
+    }
+}

--- a/nemo/src/model/rule_model/atom.rs
+++ b/nemo/src/model/rule_model/atom.rs
@@ -68,4 +68,25 @@ impl Atom {
             _ => None,
         })
     }
+
+    /// Replace one [`Term`] with another.
+    pub fn replace_term(&mut self, old: &Term, new: &Term) {
+        for tree in &mut self.term_trees {
+            tree.replace_term(old, new);
+        }
+    }
+}
+
+impl std::fmt::Display for Atom {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.predicate.fmt(f)?;
+        f.write_str("(")?;
+        for (index, tree) in self.terms().enumerate() {
+            tree.fmt(f)?;
+            if index < self.term_trees.len() - 1 {
+                f.write_str(", ")?;
+            }
+        }
+        f.write_str(")")
+    }
 }

--- a/nemo/src/model/rule_model/atom.rs
+++ b/nemo/src/model/rule_model/atom.rs
@@ -1,3 +1,5 @@
+use crate::model::VariableAssignment;
+
 use super::{Aggregate, Identifier, Term, TermTree, Variable};
 
 /// An atom.
@@ -70,9 +72,9 @@ impl Atom {
     }
 
     /// Replace one [`Term`] with another.
-    pub fn replace_term(&mut self, old: &Term, new: &Term) {
+    pub fn apply_assignment(&mut self, assignment: &VariableAssignment) {
         for tree in &mut self.term_trees {
-            tree.replace_term(old, new);
+            tree.apply_assignment(assignment);
         }
     }
 }

--- a/nemo/src/model/rule_model/filter.rs
+++ b/nemo/src/model/rule_model/filter.rs
@@ -32,6 +32,19 @@ impl FilterOperation {
     }
 }
 
+impl std::fmt::Display for FilterOperation {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            FilterOperation::Equals => f.write_str("="),
+            FilterOperation::Unequals => f.write_str("!="),
+            FilterOperation::LessThan => f.write_str("<"),
+            FilterOperation::GreaterThan => f.write_str(">"),
+            FilterOperation::LessThanEq => f.write_str("<="),
+            FilterOperation::GreaterThanEq => f.write_str(">="),
+        }
+    }
+}
+
 /// Filter of the form `<variable> <operation> <term>`
 #[derive(Debug, Eq, PartialEq, Clone, PartialOrd, Ord)]
 pub struct Filter {
@@ -56,5 +69,24 @@ impl Filter {
     /// Creates a new [`Filter]` with the arguments flipped
     pub fn flipped(operation: FilterOperation, lhs: Term, rhs: Variable) -> Self {
         Self::new(operation.flip(), rhs, lhs)
+    }
+
+    /// Replace one [`Term`] with another.
+    pub fn replace_term(&mut self, old: &Term, new: &Term) {
+        if &self.rhs == old {
+            self.rhs = new.clone();
+        }
+
+        // TODO: What about self.lhs?
+    }
+}
+
+impl std::fmt::Display for Filter {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.lhs.fmt(f)?;
+        f.write_str(" ")?;
+        self.operation.fmt(f)?;
+        f.write_str(" ")?;
+        self.rhs.fmt(f)
     }
 }

--- a/nemo/src/model/rule_model/filter.rs
+++ b/nemo/src/model/rule_model/filter.rs
@@ -1,3 +1,5 @@
+use crate::model::VariableAssignment;
+
 use super::{Term, Variable};
 
 /// Operation for a filter
@@ -72,9 +74,11 @@ impl Filter {
     }
 
     /// Replace one [`Term`] with another.
-    pub fn replace_term(&mut self, old: &Term, new: &Term) {
-        if &self.rhs == old {
-            self.rhs = new.clone();
+    pub fn apply_assignment(&mut self, assignment: &VariableAssignment) {
+        if let Term::Variable(variable) = &self.rhs {
+            if let Some(replacing_term) = assignment.get(variable) {
+                self.rhs = replacing_term.clone();
+            }
         }
 
         // TODO: What about self.lhs?

--- a/nemo/src/model/rule_model/literal.rs
+++ b/nemo/src/model/rule_model/literal.rs
@@ -74,7 +74,7 @@ impl Literal {
         forward_to_atom!(self, existential_variables)
     }
 
-    /// Replace one [`Term`] with another.
+    /// Replace one term with another.
     pub fn apply_assignment(&mut self, assignment: &VariableAssignment) {
         match self {
             Literal::Positive(atom) => atom.apply_assignment(assignment),

--- a/nemo/src/model/rule_model/literal.rs
+++ b/nemo/src/model/rule_model/literal.rs
@@ -1,6 +1,6 @@
 use std::ops::Neg;
 
-use super::{Atom, Identifier, TermTree, Variable};
+use super::{Atom, Identifier, Term, TermTree, Variable};
 
 /// A literal.
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -70,5 +70,24 @@ impl Literal {
     /// Return the existentially quantified variables in the literal.
     pub fn existential_variables(&self) -> impl Iterator<Item = &Variable> + '_ {
         forward_to_atom!(self, existential_variables)
+    }
+
+    /// Replace one [`Term`] with another.
+    pub fn replace_term(&mut self, old: &Term, new: &Term) {
+        match self {
+            Literal::Positive(atom) => atom.replace_term(old, new),
+            Literal::Negative(atom) => atom.replace_term(old, new),
+        }
+    }
+}
+
+impl std::fmt::Display for Literal {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Literal::Positive(_) => {}
+            Literal::Negative(_) => f.write_str("~")?,
+        }
+
+        self.atom().fmt(f)
     }
 }

--- a/nemo/src/model/rule_model/literal.rs
+++ b/nemo/src/model/rule_model/literal.rs
@@ -1,6 +1,8 @@
 use std::ops::Neg;
 
-use super::{Atom, Identifier, Term, TermTree, Variable};
+use crate::model::VariableAssignment;
+
+use super::{Atom, Identifier, TermTree, Variable};
 
 /// A literal.
 #[derive(Debug, Eq, PartialEq, Clone)]
@@ -73,10 +75,10 @@ impl Literal {
     }
 
     /// Replace one [`Term`] with another.
-    pub fn replace_term(&mut self, old: &Term, new: &Term) {
+    pub fn apply_assignment(&mut self, assignment: &VariableAssignment) {
         match self {
-            Literal::Positive(atom) => atom.replace_term(old, new),
-            Literal::Negative(atom) => atom.replace_term(old, new),
+            Literal::Positive(atom) => atom.apply_assignment(assignment),
+            Literal::Negative(atom) => atom.apply_assignment(assignment),
         }
     }
 }

--- a/nemo/src/model/rule_model/program.rs
+++ b/nemo/src/model/rule_model/program.rs
@@ -11,6 +11,12 @@ use super::{Atom, DataSourceDeclaration, Identifier, QualifiedPredicateName, Rul
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub struct Fact(pub Atom);
 
+impl std::fmt::Display for Fact {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// A statement that can occur in the program.
 #[derive(Debug, Eq, PartialEq, Clone)]
 pub enum Statement {

--- a/nemo/src/model/rule_model/rule.rs
+++ b/nemo/src/model/rule_model/rule.rs
@@ -1,6 +1,6 @@
 use std::collections::HashSet;
 
-use crate::io::parser::ParseError;
+use crate::{io::parser::ParseError, model::VariableAssignment};
 
 use super::{Atom, Filter, Literal, Term, Variable};
 
@@ -179,12 +179,12 @@ impl Rule {
     }
 
     /// Replace one [`Term`] with another.
-    pub fn replace_term(&mut self, old: &Term, new: &Term) {
-        self.body.iter_mut().for_each(|l| l.replace_term(old, new));
-        self.head.iter_mut().for_each(|a| a.replace_term(old, new));
+    pub fn apply_assignment(&mut self, assignment: &VariableAssignment) {
+        self.body.iter_mut().for_each(|l| l.apply_assignment(assignment));
+        self.head.iter_mut().for_each(|a| a.apply_assignment(assignment));
         self.filters
             .iter_mut()
-            .for_each(|f| f.replace_term(old, new));
+            .for_each(|f| f.apply_assignment(assignment));
     }
 }
 

--- a/nemo/src/model/rule_model/rule.rs
+++ b/nemo/src/model/rule_model/rule.rs
@@ -177,6 +177,15 @@ impl Rule {
     pub fn filters_mut(&mut self) -> &mut Vec<Filter> {
         &mut self.filters
     }
+
+    /// Replace one [`Term`] with another.
+    pub fn replace_term(&mut self, old: &Term, new: &Term) {
+        self.body.iter_mut().for_each(|l| l.replace_term(old, new));
+        self.head.iter_mut().for_each(|a| a.replace_term(old, new));
+        self.filters
+            .iter_mut()
+            .for_each(|f| f.replace_term(old, new));
+    }
 }
 
 impl std::fmt::Display for Rule {

--- a/nemo/src/model/rule_model/rule.rs
+++ b/nemo/src/model/rule_model/rule.rs
@@ -180,8 +180,12 @@ impl Rule {
 
     /// Replace one [`Term`] with another.
     pub fn apply_assignment(&mut self, assignment: &VariableAssignment) {
-        self.body.iter_mut().for_each(|l| l.apply_assignment(assignment));
-        self.head.iter_mut().for_each(|a| a.apply_assignment(assignment));
+        self.body
+            .iter_mut()
+            .for_each(|l| l.apply_assignment(assignment));
+        self.head
+            .iter_mut()
+            .for_each(|a| a.apply_assignment(assignment));
         self.filters
             .iter_mut()
             .for_each(|f| f.apply_assignment(assignment));

--- a/nemo/src/model/rule_model/rule.rs
+++ b/nemo/src/model/rule_model/rule.rs
@@ -178,3 +178,39 @@ impl Rule {
         &mut self.filters
     }
 }
+
+impl std::fmt::Display for Rule {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        for (index, atom) in self.head.iter().enumerate() {
+            atom.fmt(f)?;
+
+            if index < self.head.len() - 1 {
+                f.write_str(", ")?;
+            }
+        }
+
+        f.write_str(" :- ")?;
+
+        for (index, literal) in self.body.iter().enumerate() {
+            literal.fmt(f)?;
+
+            if index < self.body.len() - 1 {
+                f.write_str(", ")?;
+            }
+        }
+
+        if !self.filters.is_empty() {
+            f.write_str(", ")?;
+        }
+
+        for (index, filter) in self.filters.iter().enumerate() {
+            filter.fmt(f)?;
+
+            if index < self.filters.len() - 1 {
+                f.write_str(", ")?;
+            }
+        }
+
+        f.write_str(" .")
+    }
+}

--- a/nemo/src/model/rule_model/term.rs
+++ b/nemo/src/model/rule_model/term.rs
@@ -109,7 +109,12 @@ impl Variable {
 
 impl std::fmt::Display for Variable {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", &self.name())
+        let prefix = match self {
+            Variable::Universal(_) => "?",
+            Variable::Existential(_) => "!",
+        };
+
+        write!(f, "{}{}", prefix, &self.name())
     }
 }
 

--- a/nemo/src/model/rule_model/term.rs
+++ b/nemo/src/model/rule_model/term.rs
@@ -108,18 +108,12 @@ impl Variable {
 
     /// Return whether this is a universal variable.
     pub fn is_universal(&self) -> bool {
-        match self {
-            Variable::Universal(_) => true,
-            Variable::Existential(_) => false,
-        }
+        matches!(self, Variable::Universal(_))
     }
 
     /// Return whether this is an existential variable.
     pub fn is_existential(&self) -> bool {
-        match self {
-            Variable::Universal(_) => false,
-            Variable::Existential(_) => true,
-        }
+        matches!(self, Variable::Existential(_))
     }
 }
 

--- a/nemo/src/model/rule_model/term.rs
+++ b/nemo/src/model/rule_model/term.rs
@@ -105,6 +105,22 @@ impl Variable {
             Self::Universal(identifier) | Self::Existential(identifier) => identifier.name(),
         }
     }
+
+    /// Return whether this is a universal variable.
+    pub fn is_universal(&self) -> bool {
+        match self {
+            Variable::Universal(_) => true,
+            Variable::Existential(_) => false,
+        }
+    }
+
+    /// Return whether this is an existential variable.
+    pub fn is_existential(&self) -> bool {
+        match self {
+            Variable::Universal(_) => false,
+            Variable::Existential(_) => true,
+        }
+    }
 }
 
 impl std::fmt::Display for Variable {

--- a/nemo/src/model/rule_model/term_operation.rs
+++ b/nemo/src/model/rule_model/term_operation.rs
@@ -1,5 +1,7 @@
 use nemo_physical::util::TaggedTree;
 
+use crate::model::VariableAssignment;
+
 use super::{Identifier, Term, Variable};
 
 /// Supported operations between terms.
@@ -87,11 +89,13 @@ impl TermTree {
     }
 
     /// Replace one [`Term`] with another.
-    pub fn replace_term(&mut self, old: &Term, new: &Term) {
+    pub fn apply_assignment(&mut self, assignment: &VariableAssignment) {
         for leaf_node in self.0.leaves_mut() {
             if let TermOperation::Term(term) = leaf_node {
-                if term == old {
-                    *term = new.clone();
+                if let Term::Variable(variable) = term {
+                    if let Some(replacing_term) = assignment.get(variable) {
+                        *term = replacing_term.clone();
+                    }
                 }
             } else {
                 unreachable!("Leaf nodes must be terms");

--- a/nemo/src/model/types/primitive_logical_value.rs
+++ b/nemo/src/model/types/primitive_logical_value.rs
@@ -110,6 +110,17 @@ struct DatatypeValue(String, String);
 #[derive(Clone, Debug, PartialEq, Eq)]
 struct Decimal(i64, u64);
 
+impl From<PrimitiveLogicalValueT> for Term {
+    fn from(value: PrimitiveLogicalValueT) -> Self {
+        match value {
+            PrimitiveLogicalValueT::Any(term) => term,
+            PrimitiveLogicalValueT::String(value) => value.into(),
+            PrimitiveLogicalValueT::Integer(value) => value.into(),
+            PrimitiveLogicalValueT::Float64(value) => value.into(),
+        }
+    }
+}
+
 impl From<LogicalString> for Term {
     fn from(value: LogicalString) -> Self {
         Self::StringLiteral(value.into())

--- a/nemo/src/model/types/primitive_types.rs
+++ b/nemo/src/model/types/primitive_types.rs
@@ -145,6 +145,16 @@ impl PrimitiveType {
         Ok(result)
     }
 
+    /// Associate a physical data type to this primitive logical type
+    pub fn datatype_name(&self) -> DataTypeName {
+        match self {
+            PrimitiveType::Any => DataTypeName::String,
+            PrimitiveType::String => DataTypeName::String,
+            PrimitiveType::Integer => DataTypeName::I64,
+            PrimitiveType::Float64 => DataTypeName::Double,
+        }
+    }
+
     /// Whether this logical type can be used to perform numeric operations.
     pub fn allows_numeric_operations(&self) -> bool {
         match self {

--- a/nemo/src/table_manager.rs
+++ b/nemo/src/table_manager.rs
@@ -367,6 +367,11 @@ impl TableManager {
         }
     }
 
+    /// Return a reference to the underlying [`DatabaseInstance`].
+    pub fn database(&self) -> &DatabaseInstance {
+        &self.database
+    }
+
     /// Return the [`TableId`] that is associated with a given subtable.
     /// Returns `None` if the predicate does not exist.
     fn table_id(&self, subtable: &SubtableIdentifier) -> Option<TableId> {
@@ -458,6 +463,11 @@ impl TableManager {
             .insert(predicate.clone(), predicate_info);
         self.predicate_subtables
             .insert(predicate, SubtableHandler::default());
+    }
+
+    /// Check whether a predicate has been registered.
+    pub fn predicate_exists(&self, predicate: &Identifier) -> bool {
+        self.predicate_subtables.get(predicate).is_some()
     }
 
     fn add_subtable(&mut self, subtable: SubtableIdentifier, table_id: TableId) {
@@ -637,12 +647,12 @@ impl TableManager {
 
     /// Return the chase step of the sub table that contains the given row within the given predicate.
     /// Returns `None` if the row does not exist.
-    pub fn find_table_row(&self, predicate: Identifier, row: TableRow) -> Option<usize> {
-        let handler = self.predicate_subtables.get(&predicate)?;
+    pub fn find_table_row(&self, predicate: &Identifier, row: &TableRow) -> Option<usize> {
+        let handler = self.predicate_subtables.get(predicate)?;
 
         for (step, id) in &handler.single {
             let (trie, order) = self.database.get_trie(*id);
-            let row_reorderd = order.permute(&row);
+            let row_reorderd = order.permute(row);
 
             if trie.contains_row(row_reorderd) {
                 return Some(*step);
@@ -650,6 +660,24 @@ impl TableManager {
         }
 
         None
+    }
+
+    /// Execute a given [`SubtableExecutionPlan`]
+    /// but evaluate it only until the first row of the result table
+    /// or return `None` if it is empty.
+    /// The result table is considered to be the (unique) table marked as permanent output.
+    ///
+    /// Assumes that the given plan has only one output node.
+    /// No tables will be saved in the database.
+    pub fn execute_plan_first_match(
+        &self,
+        subtable_plan: SubtableExecutionPlan,
+    ) -> Result<Option<TableRow>, Error> {
+        debug_assert!(subtable_plan.map_subtrees.len() == 1);
+
+        Ok(self
+            .database
+            .execute_plan_first_match(subtable_plan.execution_plan)?)
     }
 }
 


### PR DESCRIPTION
This PR implements tracing, i.e. the functionality to output the origin of a derived fact. This can be done via the new command `--trace <Atom>`.

E.g. on program 
```
P(?x, ?y) :- Q(?y, ?x) .
S(?x) :- T(?x) .
R(?x, ?y) :- P(?x, ?y), S(?y) .

Q(a, b).
T(a). 
```
running `nmo --trace "R(b, a)"` produces 
```
 R(b, a) :- P(b, a), S(a) .
 ├─ P(b, a) :- Q(a, b) .
 │  └─ Q(a, b)
 └─ S(a) :- T(a) .
    └─ T(a)
```

Tracing is currently disabled for rules with arithmetic operations. Running the command on such rules will result in a user error. The reason for this is that this would require an implementation of arithmetic operators for filtering body matches.