### PR TITLE
Add tracing for head arithmetic

### DIFF
--- a/nemo/src/error.rs
+++ b/nemo/src/error.rs
@@ -17,7 +17,7 @@ pub use nemo_physical::error::ReadingError;
 pub enum Error {
     /// Currently tracing doesn't work for all language features
     #[error(
-        "Tracing is currently not supported for rules with arithmetic operations in the head."
+        "Tracing is currently not supported for some rules with arithmetic operations in the head."
     )]
     TraceUnsupportedFeature(),
     /// Error which implies a needed Rollback

--- a/nemo/src/execution/planning.rs
+++ b/nemo/src/execution/planning.rs
@@ -19,4 +19,4 @@ pub mod plan_util;
 
 pub mod negation;
 
-mod arithmetic;
+pub mod arithmetic;

--- a/nemo/src/execution/planning/arithmetic.rs
+++ b/nemo/src/execution/planning/arithmetic.rs
@@ -17,7 +17,9 @@ use crate::{
     program_analysis::variable_order::VariableOrder,
 };
 
-pub(super) fn termtree_to_arithmetictree(
+/// Builds an [`ArithmeticTree`] with [`DataValueT`]
+/// from a given [`Term`].
+pub fn termtree_to_arithmetictree(
     term: &Term,
     order: &VariableOrder,
     logical_type: &PrimitiveType,

--- a/nemo/src/model/rule_model/numeric_literal.rs
+++ b/nemo/src/model/rule_model/numeric_literal.rs
@@ -1,7 +1,7 @@
 use nemo_physical::datatypes::Double;
 
 /// A numerical literal.
-#[derive(Debug, Eq, PartialEq, Copy, Clone, PartialOrd, Ord)]
+#[derive(Eq, PartialEq, Copy, Clone, PartialOrd, Ord)]
 pub enum NumericLiteral {
     /// An integer literal.
     Integer(i64),
@@ -11,12 +11,24 @@ pub enum NumericLiteral {
     Double(Double),
 }
 
-impl std::fmt::Display for NumericLiteral {
+impl std::fmt::Debug for NumericLiteral {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             NumericLiteral::Integer(value) => write!(f, "{value}"),
             NumericLiteral::Decimal(left, right) => write!(f, "{left}.{right}"),
             NumericLiteral::Double(value) => write!(f, "{:E}", f64::from(*value)),
+        }
+    }
+}
+
+impl std::fmt::Display for NumericLiteral {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            NumericLiteral::Integer(value) => write!(f, "{value}"),
+            NumericLiteral::Decimal(left, right) => write!(f, "{left}.{right}"),
+            NumericLiteral::Double(value) => {
+                f.write_str(format!("{:.4}", f64::from(*value)).trim_end_matches(['.', '0']))
+            }
         }
     }
 }

--- a/nemo/src/model/rule_model/term.rs
+++ b/nemo/src/model/rule_model/term.rs
@@ -4,7 +4,7 @@ use nemo_physical::{
     columnar::operations::arithmetic::traits::{CheckedPow, CheckedSquareRoot},
     datatypes::{DataValueT, Double},
 };
-use num::{traits::CheckedNeg, Zero};
+use num::{traits::CheckedNeg, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, Zero};
 
 use crate::model::{
     types::primitive_logical_value::LOGICAL_NULL_PREFIX, PrimitiveType, VariableAssignment,
@@ -400,10 +400,14 @@ impl Term {
                 let value_right = right.evaluate_constant_numeric()?;
 
                 match binary {
-                    BinaryOperation::Addition(_, _) => Some(value_left + value_right),
-                    BinaryOperation::Subtraction(_, _) => Some(value_left - value_right),
-                    BinaryOperation::Multiplication(_, _) => Some(value_left * value_right),
-                    BinaryOperation::Division(_, _) => Some(value_left / value_right),
+                    BinaryOperation::Addition(_, _) => Some(value_left.checked_add(&value_right)?),
+                    BinaryOperation::Subtraction(_, _) => {
+                        Some(value_left.checked_sub(&value_right)?)
+                    }
+                    BinaryOperation::Multiplication(_, _) => {
+                        Some(value_left.checked_mul(&value_right)?)
+                    }
+                    BinaryOperation::Division(_, _) => Some(value_left.checked_div(&value_right)?),
                     BinaryOperation::Exponent(_, _) => Some(value_left.checked_pow(value_right)?),
                 }
             }


### PR DESCRIPTION
Allows tracing for rules that compute new values in the head. For example: 

```
project_reject("Wind Turbine B") :- distance("Wind Turbine B", 30.965), 30.965 < 200 .
 └─ distance("Wind Turbine B", 30.965) :- project_location_m("Wind Turbine B", 1525632.5746, 4578188.0003), positions_m(1525619.4715, 4578216.0563), 30.965 = sqrt((1525632.5746 - 1525619.4715) * (1525632.5746 - 1525619.4715) + (4578188.0003 - 4578216.0563) * (4578188.0003 - 4578216.0563)) .
    ├─ project_location_m("Wind Turbine B", 1525632.5746, 4578188.0003) :- project_location("Wind Turbine B", 13.7049, 50.8982), 1525632.5746 = 13.7049 * 111320, 4578188.0003 = 50.8982 * 89948 .
    │  └─ project_location("Wind Turbine B", 13.7049, 50.8982)
    └─ positions_m(1525619.4715, 4578216.0563) :- locations(13.7048, 50.8985, "856", "1913826124", "", "", "", "", "", "", "", "", ""natural"=>"tree""), 1525619.4715 = 13.7048 * 111320, 4578216.0563 = 50.8985 * 89948 .
       └─ locations(13.7048, 50.8985, "856", "1913826124", "", "", "", "", "", "", "", "", ""natural"=>"tree"")
```