### PR TITLE
Don't run miri on slow unit tests

### DIFF
--- a/nemo/src/io/parser.rs
+++ b/nemo/src/io/parser.rs
@@ -1372,6 +1372,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn source() {
         let parser = RuleParser::new();
         let file = "drinks.csv";
@@ -1634,6 +1635,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn filter() {
         let parser = RuleParser::new();
         let aa = "A";
@@ -1778,6 +1780,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_arithmetic_expressions() {
         let parser = RuleParser::new();
 
@@ -1860,6 +1863,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn program_statement_order() {
         assert_matches!(
             parse_program(
@@ -1898,6 +1902,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_function_terms() {
         let parser = RuleParser::new();
 

--- a/nemo/src/program_analysis/analysis.rs
+++ b/nemo/src/program_analysis/analysis.rs
@@ -1573,6 +1573,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn overloading_is_unsupported() {
         let program = ChaseProgram::try_from(
             parse_program(

--- a/nemo/src/program_analysis/variable_order.rs
+++ b/nemo/src/program_analysis/variable_order.rs
@@ -972,6 +972,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn build_preferable_variable_orders_with_galen_el_part_ie_5_rules_without_constant() {
         let (rules, var_lists, predicates) =
             get_part_of_galen_test_ruleset_ie_first_5_rules_without_constant();
@@ -1343,6 +1344,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn build_preferable_variable_orders_with_el_without_constant() {
         let (rules, var_lists, predicates) = get_el_test_ruleset_without_constants();
 


### PR DESCRIPTION
This brings down the total run time for `cargo miri test` by over 10 minutes on my machine.