### PR TITLE
patch: shortening primitive logical value prefixes

### DIFF
--- a/nemo/src/builder_proxy.rs
+++ b/nemo/src/builder_proxy.rs
@@ -653,38 +653,44 @@ mod test {
             unreachable!()
         };
 
-        assert_eq!(any_result, [
-            "STRING:my string",
-            "INTEGER:42",
-            "DOUBLE:3.41",
-            "CONSTANT:my constant",
-            "STRING:string literal",
-            "INTEGER:45",
-            "DECIMAL:4.2",
-            "DOUBLE:2.99",
-            "LANGUAGE_STRING:language string@en",
-            "DATATYPE_VALUE:some random datavalue^^a datatype that I totally did not just make up",
-            "STRING:string datavalue",
-            "INTEGER:73",
-            "DECIMAL:1.23",
-            "DECIMAL:1.23",
-            "DECIMAL:-1.23",
-            "DECIMAL:23.0",
-            "DECIMAL:23.0",
-            "DECIMAL:-23.0",
-            "DOUBLE:3.33",
-            "DATATYPE_VALUE:9950000000000000000^^http://www.w3.org/2001/XMLSchema#integer",
-            "DATATYPE_VALUE:9950000000000000001^^http://www.w3.org/2001/XMLSchema#decimal",
-        ].into_iter().map(String::from).collect::<Vec<_>>());
+        assert_eq!(
+            any_result,
+            [
+                "ST:my string",
+                "IN:42",
+                "DO:3.41",
+                "CO:my constant",
+                "ST:string literal",
+                "IN:45",
+                "DE:4.2",
+                "DO:2.99",
+                "LS:language string@en",
+                "DV:some random datavalue^^a datatype that I totally did not just make up",
+                "ST:string datavalue",
+                "IN:73",
+                "DE:1.23",
+                "DE:1.23",
+                "DE:-1.23",
+                "DE:23.0",
+                "DE:23.0",
+                "DE:-23.0",
+                "DO:3.33",
+                "DV:9950000000000000000^^http://www.w3.org/2001/XMLSchema#integer",
+                "DV:9950000000000000001^^http://www.w3.org/2001/XMLSchema#decimal",
+            ]
+            .into_iter()
+            .map(String::from)
+            .collect::<Vec<_>>()
+        );
 
         assert_eq!(
             string_result,
             [
-                "STRING:my string",
-                "STRING:42",
-                "STRING:3.41",
-                "STRING:string literal",
-                "STRING:string datavalue",
+                "ST:my string",
+                "ST:42",
+                "ST:3.41",
+                "ST:string literal",
+                "ST:string datavalue",
             ]
             .into_iter()
             .map(String::from)

--- a/nemo/src/model/types/primitive_logical_value.rs
+++ b/nemo/src/model/types/primitive_logical_value.rs
@@ -15,13 +15,13 @@ use crate::model::{
 
 use super::{error::InvalidRuleTermConversion, primitive_types::PrimitiveType};
 
-const LANGUAGE_STRING_PREFIX: &str = "LANGUAGE_STRING:";
-const STRING_PREFIX: &str = "STRING:";
-const INTEGER_PREFIX: &str = "INTEGER:";
-const DECIMAL_PREFIX: &str = "DECIMAL:";
-const DOUBLE_PREFIX: &str = "DOUBLE:";
-const CONSTANT_PREFIX: &str = "CONSTANT:";
-const DATATYPE_VALUE_PREFIX: &str = "DATATYPE_VALUE:";
+const LANGUAGE_STRING_PREFIX: &str = "LS:";
+const STRING_PREFIX: &str = "ST:";
+const INTEGER_PREFIX: &str = "IN:";
+const DECIMAL_PREFIX: &str = "DE:";
+const DOUBLE_PREFIX: &str = "DO:";
+const CONSTANT_PREFIX: &str = "CO:";
+const DATATYPE_VALUE_PREFIX: &str = "DV:";
 
 /// The prefix used to indicate constants that are Nulls
 pub const LOGICAL_NULL_PREFIX: &str = "__Null#";


### PR DESCRIPTION
Currently primitive logical values uses prefixes to distinguish among data types
Prefixes lengths range from 7 to 16 characters, which uses unnecessary memory

In this (patch) pull request we shorten all all prefixes to 3 characters and update tests accordingly

Experiments show memory savings up to ~300MB when loading 100M triples from Wikidata

