### PR TITLE
Feature/376 compact tracing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1245,6 +1245,8 @@ dependencies = [
  "rio_turtle",
  "rio_xml",
  "sanitise-file-name",
+ "serde",
+ "serde_json",
  "test-log",
  "thiserror",
  "tokio",
@@ -1279,6 +1281,7 @@ dependencies = [
  "log",
  "nemo",
  "predicates",
+ "serde_json",
  "test-log",
 ]
 

--- a/nemo-cli/Cargo.toml
+++ b/nemo-cli/Cargo.toml
@@ -18,6 +18,7 @@ log = { version = "0.4", features = [ "max_level_trace", "release_max_level_info
 clap = { version = "4.0.32", features = [ "derive", "cargo", "env" ] }
 colored = "2"
 env_logger = "*"
+serde_json = "1.0.108"
 
 nemo = { path = "../nemo" }
 

--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -135,7 +135,7 @@ pub struct CliApp {
     /// Specify directory for input files.
     #[arg(short = 'I', long = "input-dir")]
     pub input_directory: Option<PathBuf>,
-    /// Specify a fact, the origin of which should be explained
-    #[arg(long = "trace")]
-    pub trace_fact: Option<String>,
+    /// Specify a semicolon seperated list of facts whose origins should be explained
+    #[arg(long = "trace", value_delimiter = ';')]
+    pub trace_facts: Option<Vec<String>>,
 }

--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -106,6 +106,18 @@ impl OutputArgs {
     }
 }
 
+/// Cli arguments related to tracing
+#[derive(Debug, clap::Args)]
+pub struct TracingArgs {
+    /// Specify a fact, the origin of which should be explained
+    #[arg(long = "trace", value_delimiter = ';')]
+    pub traced_facts: Option<Vec<String>>,
+    /// Specify a file to save the trace.
+    /// (Only relevant if --trace is set.)
+    #[arg(long = "trace-output", requires = "traced_facts")]
+    pub output_file: Option<PathBuf>,
+}
+
 /// Nemo CLI
 #[derive(clap::Parser, Debug)]
 #[command(author, version, about)]
@@ -135,7 +147,7 @@ pub struct CliApp {
     /// Specify directory for input files.
     #[arg(short = 'I', long = "input-dir")]
     pub input_directory: Option<PathBuf>,
-    /// Specify a semicolon seperated list of facts whose origins should be explained
-    #[arg(long = "trace", value_delimiter = ';')]
-    pub trace_facts: Option<Vec<String>>,
+    /// Arguments related to tracing
+    #[command(flatten)]
+    pub tracing: TracingArgs,
 }

--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -109,7 +109,7 @@ impl OutputArgs {
 /// Cli arguments related to tracing
 #[derive(Debug, clap::Args)]
 pub struct TracingArgs {
-    /// Specify a fact, the origin of which should be explained
+    /// Specify a fact or multiple semicolon separated facts, the origin of which should be explained
     #[arg(long = "trace", value_delimiter = ';')]
     pub traced_facts: Option<Vec<String>>,
     /// Specify a file to save the trace.

--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -117,7 +117,17 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
     log::info!("Rules parsed");
     log::trace!("{:?}", program);
 
-    let parsed_fact = cli.trace_fact.map(parse_fact).transpose()?;
+    for atom in program.rules().iter().flat_map(|rule| rule.head()) {
+        if atom.aggregates().next().is_some() {
+            log::warn!("Program is using the experimental aggregates feature and currently depends on the internally chosen variable orders for predicates.",);
+            break;
+        }
+    }
+
+    let parsed_facts = cli
+        .trace_facts
+        .map(|f| f.into_iter().map(parse_fact).collect::<Result<Vec<_>, _>>())
+        .transpose()?;
 
     if cli.write_all_idb_predicates {
         program.force_output_predicate_selection(OutputPredicateSelection::AllIDBPredicates)
@@ -192,11 +202,15 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
         println!("\n{}", engine.memory_usage());
     }
 
-    if let Some(fact) = parsed_fact {
-        if let Some(trace) = engine.trace(fact.clone())? {
-            println!("\n{trace}");
-        } else {
-            println!("{fact} was not derived");
+    if let Some(facts) = parsed_facts {
+        let (trace, handles) = engine.trace(facts.clone())?;
+
+        for (fact, handle_opt) in facts.into_iter().zip(handles) {
+            if let Some(handle) = handle_opt {
+                println!("\n{}", trace.ascii_tree_string(handle).expect("Every handle returned from trace function should lead to a successful derivation"));
+            } else {
+                println!("{fact} was not derived");
+            }
         }
     }
 

--- a/nemo-python/src/lib.rs
+++ b/nemo-python/src/lib.rs
@@ -314,7 +314,7 @@ impl NemoEngine {
             .first()
             .expect("Function trace always returns a handle for each input fact");
 
-        Ok(trace.tree(handle).map(|tree| NemoTrace(tree)))
+        Ok(trace.tree(handle).map(NemoTrace))
     }
 
     fn write_result(

--- a/nemo-wasm/src/lib.rs
+++ b/nemo-wasm/src/lib.rs
@@ -308,14 +308,7 @@ impl NemoEngine {
             .map_err(WasmOrInternalNemoError::NemoError)
             .map_err(NemoError)?;
 
-        Ok(handles[0].map(|h| {
-            format!(
-                "{}",
-                trace
-                    .ascii_tree_string(h)
-                    .expect("Returned handle must lead to succesful derivation")
-            )
-        }))
+        Ok(trace.ascii_tree_string(handles[0]))
     }
 }
 

--- a/nemo-wasm/src/lib.rs
+++ b/nemo-wasm/src/lib.rs
@@ -302,13 +302,20 @@ impl NemoEngine {
             .map_err(WasmOrInternalNemoError::NemoError)
             .map_err(NemoError)?;
 
-        let trace = self
+        let (trace, handles) = self
             .0
-            .trace(parsed_fact)
+            .trace(vec![parsed_fact])
             .map_err(WasmOrInternalNemoError::NemoError)
             .map_err(NemoError)?;
 
-        Ok(trace.map(|t| format!("{t}")))
+        Ok(handles[0].map(|h| {
+            format!(
+                "{}",
+                trace
+                    .ascii_tree_string(h)
+                    .expect("Returned handle must lead to succesful derivation")
+            )
+        }))
     }
 }
 

--- a/nemo/Cargo.toml
+++ b/nemo/Cargo.toml
@@ -42,6 +42,8 @@ reqwest = { version = "0.11.18" }
 num = "0.4.0"
 bytesize = "1.2"
 ascii_tree = "0.1.1"
+serde_json = "1.0.108"
+serde = {version = "1.0.138", features = ["derive"] }
 
 [dev-dependencies]
 env_logger = "*"

--- a/nemo/src/error.rs
+++ b/nemo/src/error.rs
@@ -15,11 +15,6 @@ pub use nemo_physical::error::ReadingError;
 #[allow(variant_size_differences)]
 #[derive(Error, Debug)]
 pub enum Error {
-    /// Currently tracing doesn't work for all language features
-    #[error(
-        "Tracing is currently not supported for some rules with arithmetic operations in the head."
-    )]
-    TraceUnsupportedFeature(),
     /// Error which implies a needed Rollback
     #[error("Rollback due to csv-error")]
     Rollback(usize),
@@ -74,6 +69,12 @@ pub enum Error {
     UnknonwUnaryOpertation {
         /// The operation causing the failure
         operation: String,
+    },
+    /// Error while serializing data to a file
+    #[error("Error while serializing data to {filename}.")]
+    SerializationError {
+        /// Name of the file where data could not have been serialized into
+        filename: String,
     },
 }
 

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -31,8 +31,9 @@ use crate::{
 };
 
 use super::{
-    rule_execution::RuleExecution, selection_strategy::strategy::RuleSelectionStrategy,
-    tracing::trace::ExecutionTrace,
+    rule_execution::RuleExecution,
+    selection_strategy::strategy::RuleSelectionStrategy,
+    tracing::trace::{ExecutionTrace, FactTraceHandle, TraceDerivation, TraceStatus},
 };
 
 // Number of tables that are periodically combined into one.
@@ -399,30 +400,37 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
     }
 
     /// Recursive part of the function `trace`.
+    ///
     /// Takes as input the fact of which the trace should be computed.
-    /// The fact is passed as a predicate and its terms given as [`Term`]s and their physical values.
+    /// In addition receives the values of the terms as [`StorageValueT`].
+    ///
+    /// Returns a handle to the derived fact in the given [`ExecutionTrace`] if a valid derivation could be found.
+    /// Returns `None` otherwise.
     fn trace_recursive(
         &self,
-        fact_predicate: Identifier,
-        fact_terms: Vec<Constant>,
+        trace: &mut ExecutionTrace,
+        fact: ChaseFact,
         fact_values: Vec<StorageValueT>,
-    ) -> Result<Option<ExecutionTrace>, Error> {
+    ) -> Result<Option<FactTraceHandle>, Error> {
+        let trace_handle = trace.register_fact(fact.clone());
+
+        if let TraceStatus::Success(_) = trace.status(trace_handle) {
+            return Ok(Some(trace_handle));
+        }
+
         // Find the origin of the given fact
         let step = match self
             .table_manager
-            .find_table_row(&fact_predicate, &fact_values)
+            .find_table_row(&fact.predicate(), &fact_values)
         {
             Some(s) => s,
             None => return Ok(None),
         };
 
         if step == 0 {
-            // If fact has no predecessor rule it must have been given as an EDB fact
-
-            return Ok(Some(ExecutionTrace::Fact(ChaseFact::new(
-                fact_predicate,
-                fact_terms,
-            ))));
+            // If a fact was derived in step 0 it must have been given as an EDB fact
+            trace.update_status(trace_handle, TraceStatus::Success(TraceDerivation::Input));
+            return Ok(Some(trace_handle));
         }
 
         // Rule index of the rule that was applied to derive the given fact
@@ -432,12 +440,12 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
         let predicate_types: &Vec<PrimitiveType> = self
             .analysis
             .predicate_types
-            .get(&fact_predicate)
+            .get(&fact.predicate())
             .expect("Every predicate should be associated with a type.");
 
         // Iterate over all head atoms which could have derived the given fact
         for (head_index, head_atom) in rule.head().iter().enumerate() {
-            if head_atom.predicate() != fact_predicate {
+            if head_atom.predicate() != fact.predicate() {
                 continue;
             }
 
@@ -453,7 +461,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
             for (ty, (head_term, fact_term)) in predicate_types
                 .iter()
-                .zip(head_atom.terms().iter().zip(fact_terms.iter()))
+                .zip(head_atom.terms().iter().zip(fact.terms().iter()))
             {
                 match head_term {
                     PrimitiveTerm::Constant(constant) => {
@@ -603,7 +611,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                 node,
                 "Tracing Query",
                 "Tracing Query",
-                SubtableIdentifier::new(fact_predicate.clone(), step),
+                SubtableIdentifier::new(fact.predicate(), step),
             );
 
             if let Ok(Some(query_result)) =
@@ -645,7 +653,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                     .collect();
 
                 let mut fully_derived = true;
-                let mut subtraces = Vec::<ExecutionTrace>::new();
+                let mut subtraces = Vec::<FactTraceHandle>::new();
                 for body_atom in rule.positive_body() {
                     let next_fact_predicate = body_atom.predicate();
                     let mut next_fact_values = Vec::<StorageValueT>::new();
@@ -660,11 +668,9 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                         next_fact_terms.push(query_terms[query_index].clone());
                     }
 
-                    if let Some(trace) = self.trace_recursive(
-                        next_fact_predicate,
-                        next_fact_terms,
-                        next_fact_values,
-                    )? {
+                    let next_fact = ChaseFact::new(next_fact_predicate, next_fact_terms);
+
+                    if let Some(trace) = self.trace_recursive(trace, next_fact, next_fact_values)? {
                         subtraces.push(trace);
                     } else {
                         fully_derived = false;
@@ -676,43 +682,60 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                     continue;
                 }
 
-                return Ok(Some(ExecutionTrace::Rule(
-                    RuleApplication::new(
-                        self.input_program.rules()[rule_index].clone(),
-                        rule_assignment,
-                        head_index,
-                    ),
-                    subtraces,
-                )));
+                let rule_application =
+                    RuleApplication::new(rule_index, rule_assignment, head_index);
+
+                let derivation = TraceDerivation::Derived(rule_application, subtraces);
+                trace.update_status(trace_handle, TraceStatus::Success(derivation));
+
+                return Ok(Some(trace_handle));
             } else {
                 continue;
             }
         }
 
+        trace.update_status(trace_handle, TraceStatus::Fail);
         Ok(None)
     }
 
-    /// Return a [`ExecutionTrace`] for a given fact
-    pub fn trace(&self, fact: Fact) -> Result<Option<ExecutionTrace>, Error> {
-        let chase_fact = ChaseFact::from_flat_atom(&fact.0);
-        let predicate = fact.0.predicate();
+    /// Build an [`ExecutionTrace`] for a list of facts.
+    pub fn trace(
+        &self,
+        facts: Vec<Fact>,
+    ) -> Result<(ExecutionTrace, Vec<Option<FactTraceHandle>>), Error> {
+        let mut trace = ExecutionTrace::new(
+            self.input_program.clone(),
+            self.analysis.predicate_types.clone(),
+        );
 
-        if !self.table_manager.predicate_exists(&predicate) {
-            return Ok(None);
-        }
+        let mut handles = Vec::new();
 
-        // Convert fact into physical representation
-        let mut fact_values = Vec::<StorageValueT>::new();
-        for entry in Self::fact_to_vec(&chase_fact, &self.analysis) {
-            if let Some(value) = entry.to_storage_value(self.table_manager.get_dict().borrow_mut())
-            {
-                fact_values.push(value);
-            } else {
-                // Dictionary does not contain term
-                return Ok(None);
+        for fact in facts {
+            let chase_fact = ChaseFact::from_flat_atom(&fact.0);
+            let predicate = fact.0.predicate();
+
+            if !self.table_manager.predicate_exists(&predicate) {
+                handles.push(None);
+                continue;
             }
+
+            // Convert fact into physical representation
+            let mut fact_values = Vec::<StorageValueT>::new();
+            for entry in Self::fact_to_vec(&chase_fact, &self.analysis) {
+                if let Some(value) =
+                    entry.to_storage_value(self.table_manager.get_dict().borrow_mut())
+                {
+                    fact_values.push(value);
+                } else {
+                    // Dictionary does not contain term
+                    handles.push(None);
+                    continue;
+                }
+            }
+
+            handles.push(self.trace_recursive(&mut trace, chase_fact, fact_values)?);
         }
 
-        self.trace_recursive(predicate, chase_fact.terms().clone(), fact_values)
+        Ok((trace, handles))
     }
 }

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -723,6 +723,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
     }
 
     /// Build an [`ExecutionTrace`] for a list of facts.
+    /// Also returns a list containing a [`FactTraceHandle`] for each fact.
     pub fn trace(&self, facts: Vec<Fact>) -> Result<(ExecutionTrace, Vec<FactTraceHandle>), Error> {
         let mut trace = ExecutionTrace::new(
             self.input_program.clone(),

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -723,7 +723,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
     }
 
     /// Build an [`ExecutionTrace`] for a list of facts.
-    /// Also returns a list containing a [`FactTraceHandle`] for each fact.
+    /// Also returns a list containing a [`TraceFactHandle`] for each fact.
     pub fn trace(&self, facts: Vec<Fact>) -> Result<(ExecutionTrace, Vec<TraceFactHandle>), Error> {
         let mut trace = ExecutionTrace::new(
             self.input_program.clone(),

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -15,7 +15,7 @@ use crate::{
     error::Error,
     execution::{
         planning::{plan_body_seminaive::SeminaiveStrategy, BodyStrategy},
-        tracing::trace::RuleApplication,
+        tracing::trace::TraceRuleApplication,
     },
     io::{input_manager::InputManager, resource_providers::ResourceProviders},
     model::{
@@ -33,7 +33,7 @@ use crate::{
 use super::{
     rule_execution::RuleExecution,
     selection_strategy::strategy::RuleSelectionStrategy,
-    tracing::trace::{ExecutionTrace, FactTraceHandle, TraceDerivation, TraceStatus},
+    tracing::trace::{ExecutionTrace, TraceDerivation, TraceFactHandle, TraceStatus},
 };
 
 // Number of tables that are periodically combined into one.
@@ -423,7 +423,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
         trace: &mut ExecutionTrace,
         fact: ChaseFact,
         fact_values: Vec<StorageValueT>,
-    ) -> Result<FactTraceHandle, Error> {
+    ) -> Result<TraceFactHandle, Error> {
         let trace_handle = trace.register_fact(fact.clone());
 
         if fact.arity() != fact_values.len() {
@@ -676,7 +676,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                     .collect();
 
                 let mut fully_derived = true;
-                let mut subtraces = Vec::<FactTraceHandle>::new();
+                let mut subtraces = Vec::<TraceFactHandle>::new();
                 for body_atom in rule.positive_body() {
                     let next_fact_predicate = body_atom.predicate();
                     let mut next_fact_values = Vec::<StorageValueT>::new();
@@ -707,7 +707,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                 }
 
                 let rule_application =
-                    RuleApplication::new(rule_index, rule_assignment, head_index);
+                    TraceRuleApplication::new(rule_index, rule_assignment, head_index);
 
                 let derivation = TraceDerivation::Derived(rule_application, subtraces);
                 trace.update_status(trace_handle, TraceStatus::Success(derivation));
@@ -724,7 +724,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
     /// Build an [`ExecutionTrace`] for a list of facts.
     /// Also returns a list containing a [`FactTraceHandle`] for each fact.
-    pub fn trace(&self, facts: Vec<Fact>) -> Result<(ExecutionTrace, Vec<FactTraceHandle>), Error> {
+    pub fn trace(&self, facts: Vec<Fact>) -> Result<(ExecutionTrace, Vec<TraceFactHandle>), Error> {
         let mut trace = ExecutionTrace::new(
             self.input_program.clone(),
             self.analysis.predicate_types.clone(),

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -171,12 +171,12 @@ impl ExecutionTrace {
         }
     }
 
-    /// Return the [`TraceStatus`] of a given fact identified by its [`FactTraceHandle`].
+    /// Return the [`TraceStatus`] of a given fact identified by its [`TraceFactHandle`].
     pub(crate) fn status(&self, handle: TraceFactHandle) -> &TraceStatus {
         &self.get_fact(handle).status
     }
 
-    /// Update the [`TraceStatus`] of a given fact identified by its [`FactTraceHandle`].
+    /// Update the [`TraceStatus`] of a given fact identified by its [`TraceFactHandle`].
     pub(crate) fn update_status(&mut self, handle: TraceFactHandle, status: TraceStatus) {
         self.get_fact_mut(handle).status = status;
     }

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -4,36 +4,170 @@ use std::collections::HashMap;
 
 use ascii_tree::write_tree;
 
-use crate::model::{chase_model::ChaseFact, Constant, PrimitiveTerm, Rule, Term, Variable};
+use crate::model::{
+    chase_model::{ChaseAtom, ChaseFact},
+    Constant, Identifier, PrimitiveTerm, PrimitiveType, Program, Term, Variable,
+};
 
-/// Identifies an atom within the head of a rule
-#[derive(Debug, Clone)]
+/// Index of a rule within a [`Program`]
+type RuleIndex = usize;
+
+/// Represents the application of a rule to derive a specific fact
+#[derive(Debug)]
 pub struct RuleApplication {
-    /// The rule, that was applied.
-    pub rule: Rule,
-    /// The assignement, that was found.
-    pub assignment: HashMap<Variable, Constant>,
+    /// Index of the rule that was applied
+    rule_index: RuleIndex,
+    /// Variable assignment used during the rule application
+    assignment: HashMap<Variable, Constant>,
+    /// Index of the head atom which produced the fact under consideration
     _position: usize,
 }
 
 impl RuleApplication {
     /// Create new [`RuleApplication`].
-    pub fn new(rule: Rule, assignment: HashMap<Variable, Constant>, _position: usize) -> Self {
-        debug_assert!(_position < rule.head().len());
-
+    pub fn new(
+        rule_index: RuleIndex,
+        assignment: HashMap<Variable, Constant>,
+        _position: usize,
+    ) -> Self {
         Self {
-            rule,
+            rule_index,
             assignment,
             _position,
         }
     }
 }
 
-impl std::fmt::Display for RuleApplication {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let mut rule_applied = self.rule.clone();
+/// Handle to a traced fact within an [`ExecutionTrace`].
+#[derive(Debug, Clone, Copy)]
+pub struct FactTraceHandle(usize);
+
+/// Encodes the origin of a fact
+#[derive(Debug)]
+pub enum TraceDerivation {
+    /// Fact was part of the input to the chase
+    Input,
+    /// Fact was derived during the chase
+    Derived(RuleApplication, Vec<FactTraceHandle>),
+}
+
+/// Encodes current status of the derivation of a given fact
+#[derive(Debug)]
+pub enum TraceStatus {
+    /// It is not yet known whether this fact derived during chase
+    Unknown,
+    /// Fact was derived during the chase with the given [`Derivation`]
+    Success(TraceDerivation),
+    /// Fact was not derived during the chase
+    Fail,
+}
+
+/// Fact which was considered during the construction of an [`ExecutionTrace`]
+#[derive(Debug)]
+struct TracedFact {
+    /// The considered fact
+    fact: ChaseFact,
+    /// Its current status with resepect to its derivablity in the chase
+    status: TraceStatus,
+}
+
+/// Graph structure that encodes how certain facts were derived during the chase.
+#[derive(Debug)]
+pub struct ExecutionTrace {
+    /// Input program
+    program: Program,
+    /// Logical types associated with each predicate
+    predicate_types: HashMap<Identifier, Vec<PrimitiveType>>,
+
+    /// All the facts considered during tracing
+    facts: Vec<TracedFact>,
+}
+
+impl ExecutionTrace {
+    /// Create an empty [`ExecutionTrace`].
+    pub fn new(program: Program, predicate_types: HashMap<Identifier, Vec<PrimitiveType>>) -> Self {
+        Self {
+            program,
+            predicate_types,
+            facts: Vec::new(),
+        }
+    }
+
+    fn get_fact(&self, handle: FactTraceHandle) -> &TracedFact {
+        &self.facts[handle.0]
+    }
+
+    fn get_fact_mut(&mut self, handle: FactTraceHandle) -> &mut TracedFact {
+        &mut self.facts[handle.0]
+    }
+
+    /// Search a given [`ChaseFact`] in `self.facts`.
+    /// Also takes into account that the interpretation of a constant depends on its type.
+    fn find_fact(&self, fact: &ChaseFact) -> Option<FactTraceHandle> {
+        for (fact_index, traced_fact) in self.facts.iter().enumerate() {
+            if traced_fact.fact.predicate() != fact.predicate()
+                || traced_fact.fact.arity() != fact.arity()
+            {
+                continue;
+            }
+
+            let types = self
+                .predicate_types
+                .get(&fact.predicate())
+                .expect("Every predicate must have received type information");
+
+            let mut identical = true;
+            for (ty, (term_fact, term_traced_fact)) in types
+                .iter()
+                .zip(fact.terms().iter().zip(traced_fact.fact.terms()))
+            {
+                if ty.ground_term_to_data_value_t(term_fact.clone())
+                    != ty.ground_term_to_data_value_t(term_traced_fact.clone())
+                {
+                    identical = false;
+                    break;
+                }
+            }
+
+            if identical {
+                return Some(FactTraceHandle(fact_index));
+            }
+        }
+
+        None
+    }
+
+    /// Registers a new [`ChaseFact`].
+    pub fn register_fact(&mut self, fact: ChaseFact) -> FactTraceHandle {
+        if let Some(handle) = self.find_fact(&fact) {
+            handle
+        } else {
+            let handle = FactTraceHandle(self.facts.len());
+            self.facts.push(TracedFact {
+                fact,
+                status: TraceStatus::Unknown,
+            });
+
+            handle
+        }
+    }
+
+    /// Return the [`TraceStatus`] of a given fact identified by its [`FactTraceHandle`].
+    pub fn status(&self, handle: FactTraceHandle) -> &TraceStatus {
+        &self.get_fact(handle).status
+    }
+
+    /// Update the [`TraceStatus`] of a given fact identified by its [`FactTraceHandle`].
+    pub fn update_status(&mut self, handle: FactTraceHandle, status: TraceStatus) {
+        self.get_fact_mut(handle).status = status;
+    }
+}
+
+impl ExecutionTrace {
+    fn ascii_format_rule(&self, application: &RuleApplication) -> String {
+        let mut rule_applied = self.program.rules()[application.rule_index].clone();
         rule_applied.apply_assignment(
-            &self
+            &application
                 .assignment
                 .iter()
                 .map(|(variable, constant)| {
@@ -45,45 +179,49 @@ impl std::fmt::Display for RuleApplication {
                 .collect(),
         );
 
-        rule_applied.fmt(f)
-    }
-}
-
-/// Represents the derivation tree for one derived fact
-#[derive(Debug, Clone)]
-pub enum ExecutionTrace {
-    /// Fact was given as input
-    Fact(ChaseFact),
-    /// Fact was derived from the given rule
-    Rule(RuleApplication, Vec<ExecutionTrace>),
-}
-
-impl ExecutionTrace {
-    /// Create a new leaf node in an [`ExecutionTrace`].
-    pub fn leaf(fact: ChaseFact) -> Self {
-        ExecutionTrace::Fact(fact)
+        rule_applied.to_string()
     }
 
-    /// Create a new node in an [`ExecutionTrace`].
-    pub fn node(rule_position: RuleApplication, subtraces: Vec<ExecutionTrace>) -> Self {
-        ExecutionTrace::Rule(rule_position, subtraces)
-    }
+    /// Create an ascii tree representation starting form a particular node.
+    ///
+    /// Returns `None` if no successful derivation can be given.
+    pub fn ascii_tree(&self, handle: FactTraceHandle) -> Option<ascii_tree::Tree> {
+        let traced_fact = self.get_fact(handle);
 
-    /// Create an ascii tree representation.
-    pub fn ascii_tree(&self) -> ascii_tree::Tree {
-        match self {
-            ExecutionTrace::Fact(fact) => ascii_tree::Tree::Leaf(vec![fact.to_string()]),
-            ExecutionTrace::Rule(rule, subtraces) => {
-                let subtrees = subtraces.iter().map(|t| t.ascii_tree()).collect();
-                ascii_tree::Tree::Node(rule.to_string(), subtrees)
+        if let TraceStatus::Success(derivation) = &traced_fact.status {
+            match derivation {
+                TraceDerivation::Input => {
+                    Some(ascii_tree::Tree::Leaf(vec![traced_fact.fact.to_string()]))
+                }
+                TraceDerivation::Derived(application, subderivations) => {
+                    let mut subtrees = Vec::new();
+                    for &derivation in subderivations {
+                        if let Some(tree) = self.ascii_tree(derivation) {
+                            subtrees.push(tree);
+                        } else {
+                            return None;
+                        }
+                    }
+
+                    Some(ascii_tree::Tree::Node(
+                        self.ascii_format_rule(application),
+                        subtrees,
+                    ))
+                }
             }
+        } else {
+            None
         }
     }
-}
 
-impl std::fmt::Display for ExecutionTrace {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write_tree(f, &self.ascii_tree())
+    /// Create an ascii tree representation starting form a particular node.
+    ///
+    /// Returns `None` if no successful derivation can be given.
+    pub fn ascii_tree_string(&self, handle: FactTraceHandle) -> Option<String> {
+        let mut result = String::new();
+        write_tree(&mut result, &self.ascii_tree(handle)?).ok()?;
+
+        Some(result)
     }
 }
 
@@ -91,9 +229,12 @@ impl std::fmt::Display for ExecutionTrace {
 mod test {
     use std::collections::HashMap;
 
-    use crate::model::{
-        chase_model::ChaseFact, Atom, Constant, Identifier, Literal, PrimitiveTerm, Rule, Term,
-        Variable,
+    use crate::{
+        execution::tracing::trace::{TraceDerivation, TraceStatus},
+        model::{
+            chase_model::ChaseFact, Atom, Constant, Identifier, Literal, PrimitiveTerm,
+            PrimitiveType, Program, Rule, Term, Variable,
+        },
     };
 
     use super::{ExecutionTrace, RuleApplication};
@@ -164,32 +305,97 @@ mod test {
             ],
         );
 
+        let p_ba = ChaseFact::new(
+            Identifier("P".to_string()),
+            vec![
+                Constant::Abstract(Identifier("b".to_string())),
+                Constant::Abstract(Identifier("a".to_string())),
+            ],
+        );
+
+        let r_ba = ChaseFact::new(
+            Identifier("R".to_string()),
+            vec![
+                Constant::Abstract(Identifier("b".to_string())),
+                Constant::Abstract(Identifier("a".to_string())),
+            ],
+        );
+
         let s_a = ChaseFact::new(
             Identifier("S".to_string()),
             vec![Constant::Abstract(Identifier("a".to_string()))],
         );
 
-        let trace = ExecutionTrace::node(
-            RuleApplication::new(rule_3, rule_3_assignment, 0),
-            vec![
-                ExecutionTrace::node(
-                    RuleApplication::new(rule_1, rule_1_assignment, 0),
-                    vec![ExecutionTrace::leaf(q_ab)],
-                ),
-                ExecutionTrace::node(
-                    RuleApplication::new(rule_2, rule_2_assignment, 0),
-                    vec![ExecutionTrace::leaf(s_a)],
-                ),
-            ],
+        let t_a = ChaseFact::new(
+            Identifier("T".to_string()),
+            vec![Constant::Abstract(Identifier("a".to_string()))],
+        );
+
+        let rules = vec![rule_1, rule_2, rule_3];
+        let rule_1_index = 0;
+        let rule_2_index = 1;
+        let rule_3_index = 2;
+
+        let program = Program::from(rules);
+
+        let mut predicate_types = HashMap::new();
+        predicate_types.insert(Identifier(String::from("S")), vec![PrimitiveType::Any]);
+        predicate_types.insert(Identifier(String::from("T")), vec![PrimitiveType::Any]);
+        predicate_types.insert(
+            Identifier(String::from("Q")),
+            vec![PrimitiveType::Any, PrimitiveType::Any],
+        );
+        predicate_types.insert(
+            Identifier(String::from("P")),
+            vec![PrimitiveType::Any, PrimitiveType::Any],
+        );
+        predicate_types.insert(
+            Identifier(String::from("R")),
+            vec![PrimitiveType::Any, PrimitiveType::Any],
+        );
+
+        let mut trace = ExecutionTrace::new(program, predicate_types);
+
+        let trace_s_a = trace.register_fact(s_a);
+        let trace_t_a = trace.register_fact(t_a);
+        let trace_q_ab = trace.register_fact(q_ab);
+        let trace_p_ba = trace.register_fact(p_ba);
+        let trace_r_ba = trace.register_fact(r_ba);
+
+        trace.update_status(trace_t_a, TraceStatus::Success(TraceDerivation::Input));
+        trace.update_status(
+            trace_s_a,
+            TraceStatus::Success(TraceDerivation::Derived(
+                RuleApplication::new(rule_2_index, rule_2_assignment, 0),
+                vec![trace_t_a],
+            )),
+        );
+        trace.update_status(trace_q_ab, TraceStatus::Success(TraceDerivation::Input));
+        trace.update_status(
+            trace_p_ba,
+            TraceStatus::Success(TraceDerivation::Derived(
+                RuleApplication::new(rule_1_index, rule_1_assignment, 0),
+                vec![trace_q_ab],
+            )),
+        );
+        trace.update_status(
+            trace_r_ba,
+            TraceStatus::Success(TraceDerivation::Derived(
+                RuleApplication::new(rule_3_index, rule_3_assignment, 0),
+                vec![trace_p_ba, trace_s_a],
+            )),
         );
 
         let trace_string = r#" R(b, a) :- P(b, a), S(a) .
  ├─ P(b, a) :- Q(a, b) .
  │  └─ Q(a, b)
  └─ S(a) :- T(a) .
-    └─ S(a)
+    └─ T(a)
 "#;
 
-        assert_eq!(trace.to_string(), trace_string.to_string())
+        assert_eq!(
+            trace.ascii_tree_string(trace_r_ba).unwrap(),
+            trace_string.to_string()
+        )
     }
 }

--- a/nemo/src/model/chase_model/atom.rs
+++ b/nemo/src/model/chase_model/atom.rs
@@ -16,6 +16,11 @@ pub trait ChaseAtom {
     /// Return the terms in the atom - mutable.
     fn terms_mut(&mut self) -> &mut Vec<Self::TypeTerm>;
 
+    /// Return the arity of the atom
+    fn arity(&self) -> usize {
+        self.terms().len()
+    }
+
     /// Return a set of all variables used in this atom
     fn get_variables(&self) -> Vec<Variable>;
 }


### PR DESCRIPTION
This PR changes the internal data structure to represent an execution trace from a tree to a DAG. This allows for the possibility to perform multiple traces at the same time while reusing subtraces. One can access that feature from the CLI by providing a semicolon separated list to the `trace` command. Furthermore, this implements the json output format described in #403. This is accessible via a new command `trace-output [filename]`.

I have also allowed a method to transform the new representation into the old tree-like structure to not break the python api. But maybe this should change now as well.

Fixes #376.
Fixes #403.
