### PR TITLE
use the hashbrown::Equivalence trait instead of tmp-refs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1273,6 +1273,7 @@ dependencies = [
  "bytesize",
  "enum_dispatch",
  "env_logger 0.10.1",
+ "hashbrown",
  "howlong",
  "linked-hash-map",
  "log",

--- a/nemo-physical/Cargo.toml
+++ b/nemo-physical/Cargo.toml
@@ -31,6 +31,7 @@ rio_turtle = "0.8.4"
 rio_xml = "0.8.4"
 reqwest = "0.11.18"
 regex = "1.9.5"
+hashbrown = "0.14"
 
 [dev-dependencies]
 arbitrary = { version = "1", features = ["derive"] }


### PR DESCRIPTION
the current way to check whether some string was already present in the dictionary was sort of a hack around the `std::HashMap::get` api. Using the more general `hashbrown::HashMap` makes it possible possible to check for a value without needing to construct a key of the same type, by using the `hashbrown::Equivalence` trait. Performance should be unaffected.