### PR TITLE
Tracing playground new data model adjustments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1151,6 +1151,7 @@ dependencies = [
  "oxiri",
  "path-slash",
  "petgraph",
+ "petgraph-graphml",
  "quickcheck",
  "quickcheck_macros",
  "rand",
@@ -1471,6 +1472,16 @@ checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
  "indexmap",
+]
+
+[[package]]
+name = "petgraph-graphml"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f99237d858a7675759c308324348d81742553ed1d65ddce0854a55688e8487b"
+dependencies = [
+ "petgraph",
+ "xml-rs",
 ]
 
 [[package]]
@@ -2649,6 +2660,12 @@ checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
 ]
+
+[[package]]
+name = "xml-rs"
+version = "0.8.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fcb9cbac069e033553e8bb871be2fbdffcab578eb25bd0f7c508cedc6dcd75a"
 
 [[package]]
 name = "zerocopy"

--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -118,10 +118,11 @@ impl OutputArgs {
 #[derive(Debug, clap::Args)]
 pub(crate) struct TracingArgs {
     /// Facts for which a derivation trace should be computed;
-    /// multiple facts can be separated by a semicolon
+    /// multiple facts can be separated by a semicolon, e.g. "P(a, b);Q(c)".
     #[arg(long = "trace", value_delimiter = ';', group = "trace-input")]
     pub(crate) facts_to_be_traced: Option<Vec<String>>,
-    /// Specify an input file for the facts that should be explained
+    /// Specify one or multiple input files for the facts that should be traced.
+    /// The file format is the same as for the "trace" CLI argument.
     #[arg(long = "trace-input-file", value_parser, group = "trace-input")]
     pub(crate) trace_input_file: Option<Vec<PathBuf>>,
     /// File to export the trace to

--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -119,11 +119,14 @@ impl OutputArgs {
 pub(crate) struct TracingArgs {
     /// Facts for which a derivation trace should be computed;
     /// multiple facts can be separated by a semicolon
-    #[arg(long = "trace", value_delimiter = ';')]
-    pub(crate) traced_facts: Option<Vec<String>>,
+    #[arg(long = "trace", value_delimiter = ';', group = "trace-input")]
+    pub facts_to_be_traced: Option<Vec<String>>,
+    /// Specify an input file for the facts that should be explained
+    #[arg(long = "trace-input-file", value_parser, group = "trace-input")]
+    pub trace_input_file: Option<Vec<PathBuf>>,
     /// File to export the trace to
-    #[arg(long = "trace-output", requires = "traced_facts")]
-    pub(crate) output_file: Option<PathBuf>,
+    #[arg(long = "trace-output", requires = "trace-input")]
+    pub output_file: Option<PathBuf>,
 }
 
 /// Nemo CLI

--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -120,13 +120,13 @@ pub(crate) struct TracingArgs {
     /// Facts for which a derivation trace should be computed;
     /// multiple facts can be separated by a semicolon
     #[arg(long = "trace", value_delimiter = ';', group = "trace-input")]
-    pub facts_to_be_traced: Option<Vec<String>>,
+    pub(crate) facts_to_be_traced: Option<Vec<String>>,
     /// Specify an input file for the facts that should be explained
     #[arg(long = "trace-input-file", value_parser, group = "trace-input")]
-    pub trace_input_file: Option<Vec<PathBuf>>,
+    pub(crate) trace_input_file: Option<Vec<PathBuf>>,
     /// File to export the trace to
     #[arg(long = "trace-output", requires = "trace-input")]
-    pub output_file: Option<PathBuf>,
+    pub(crate) output_file: Option<PathBuf>,
 }
 
 /// Nemo CLI

--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -186,7 +186,7 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
                             }) {
                                 Ok(inner) => Some(inner),
                                 Err(err) => {
-                                    log::warn!("!Warning: {err}");
+                                    log::error!("!Error: Could not read trace input file {}. We continue by skipping it. Detailed error message: {err}", filename.to_string_lossy().to_string());
                                     None
                                 }
                             }

--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -170,11 +170,41 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
     log::info!("Rules parsed");
     log::trace!("{:?}", program);
 
-    let traced_facts = cli
-        .tracing
-        .traced_facts
-        .map(|f| f.into_iter().map(parse_fact).collect::<Result<Vec<_>, _>>())
-        .transpose()?;
+    let facts_to_be_traced: Option<Vec<_>> = {
+        let raw_facts_to_be_traced: Option<Vec<String>> =
+            cli.tracing.facts_to_be_traced.or_else(|| {
+                Some(
+                    cli.tracing
+                        .trace_input_file?
+                        .into_iter()
+                        .filter_map(|filename| {
+                            match read_to_string(filename.clone()).map_err(|err| {
+                                ReadingError::IoReading {
+                                    error: err,
+                                    filename: filename.to_string_lossy().to_string(),
+                                }
+                            }) {
+                                Ok(inner) => Some(inner),
+                                Err(err) => {
+                                    log::warn!("!Warning: {err}");
+                                    None
+                                }
+                            }
+                        })
+                        .flat_map(|fact_string| {
+                            fact_string
+                                .split(';')
+                                .map(|s| s.trim().to_string())
+                                .collect::<Vec<String>>()
+                        })
+                        .collect(),
+                )
+            });
+
+        raw_facts_to_be_traced
+            .map(|f| f.into_iter().map(parse_fact).collect::<Result<Vec<_>, _>>())
+            .transpose()?
+    };
 
     override_exports(&mut program, cli.output.export_setting);
 
@@ -243,7 +273,7 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
         print_memory_details(&engine);
     }
 
-    if let Some(facts) = traced_facts {
+    if let Some(facts) = facts_to_be_traced {
         let (trace, handles) = engine.trace(program.clone(), facts.clone());
 
         match cli.tracing.output_file {

--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -288,8 +288,8 @@ fn run(mut cli: CliApp) -> Result<(), Error> {
             }
             None => {
                 for (fact, handle) in facts.into_iter().zip(handles) {
-                    if let Some(tree) = trace.ascii_tree_string(handle) {
-                        println!("\n{}", tree);
+                    if let Some(tree) = trace.tree(handle) {
+                        println!("\n{}", tree.to_ascii_art());
                     } else {
                         println!("\n{fact} was not derived");
                     }

--- a/nemo-wasm/src/lib.rs
+++ b/nemo-wasm/src/lib.rs
@@ -355,7 +355,7 @@ impl NemoEngine {
 
         let (trace, handles) = self.engine.trace(self.program.0.clone(), vec![parsed_fact]);
 
-        trace.tree(handles[0]).map(|tree| tree.to_ascii_art())
+        trace.tree(handles[0]).map(|tree| tree.to_graphml())
     }
 }
 

--- a/nemo-wasm/src/lib.rs
+++ b/nemo-wasm/src/lib.rs
@@ -355,7 +355,7 @@ impl NemoEngine {
 
         let (trace, handles) = self.engine.trace(self.program.0.clone(), vec![parsed_fact]);
 
-        trace.ascii_tree_string(handles[0])
+        trace.tree(handles[0]).map(|tree| tree.to_ascii_art())
     }
 }
 

--- a/nemo/Cargo.toml
+++ b/nemo/Cargo.toml
@@ -23,6 +23,7 @@ macros = { path = "../libs/macros" }
 log = "0.4"
 nom = "7.1.1"
 petgraph = "0.6.3"
+petgraph-graphml = "3.0.0"
 rand = "0.8.5"
 csv = "1.1.6"
 thiserror = "1.0"

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -188,6 +188,7 @@ pub struct TraceTreeRuleApplication {
 }
 
 impl TraceTreeRuleApplication {
+    /// Instantiate the given rule with its assignment producing a [`Rule`] with only ground terms.
     fn to_instantiated_rule(&self) -> Rule {
         let mut rule = self.rule.clone();
         rule.apply_assignment(
@@ -205,12 +206,14 @@ impl TraceTreeRuleApplication {
         rule
     }
 
+    /// Get the [`ChaseFact`] that was produced by this rule application.
     fn to_derived_fact(&self) -> ChaseFact {
         let rule = self.to_instantiated_rule();
         let derived_atom = &rule.head()[self._position];
         ChaseFact::from_flat_atom(derived_atom)
     }
 
+    /// Get a string representation of the Instantiated rule.
     fn to_instantiated_string(&self) -> String {
         self.to_instantiated_rule().to_string()
     }

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -246,9 +246,8 @@ impl ExecutionTraceTree {
     fn to_petgraph(&self) -> DiGraph<TracePetGraphNodeLabel, ()> {
         let mut graph = DiGraph::new();
 
-        let mut parent_node_index_opt: Option<NodeIndex> = None;
-        let mut node_stack = vec![self.clone()];
-        while let Some(next_node) = node_stack.pop() {
+        let mut node_stack: Vec<(Option<NodeIndex>, Self)> = vec![(None, self.clone())];
+        while let Some((parent_node_index_opt, next_node)) = node_stack.pop() {
             let petgraph_node = match next_node {
                 Self::Fact(ref chase_fact) => TracePetGraphNodeLabel::Fact(chase_fact.clone()),
                 Self::Rule(ref trace_tree_rule_application, _) => {
@@ -260,10 +259,15 @@ impl ExecutionTraceTree {
             if let Some(parent_node_index) = parent_node_index_opt {
                 graph.add_edge(next_node_index, parent_node_index, ());
             }
-            parent_node_index_opt = Some(next_node_index);
 
             if let Self::Rule(_, subtrees) = next_node {
-                node_stack.append(&mut subtrees.clone())
+                let new_parent_node_index_opt = Some(next_node_index);
+                let mut entries_to_append: Vec<(Option<NodeIndex>, Self)> = subtrees
+                    .iter()
+                    .cloned()
+                    .map(|st| (new_parent_node_index_opt, st))
+                    .collect();
+                node_stack.append(&mut entries_to_append)
             }
         }
 

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -188,7 +188,7 @@ pub struct TraceTreeRuleApplication {
 }
 
 impl TraceTreeRuleApplication {
-    fn to_instantiated_string(&self) -> String {
+    fn to_instantiated_rule(&self) -> Rule {
         let mut rule = self.rule.clone();
         rule.apply_assignment(
             &self
@@ -202,7 +202,17 @@ impl TraceTreeRuleApplication {
                 })
                 .collect(),
         );
-        rule.to_string()
+        rule
+    }
+
+    fn to_derived_fact(&self) -> ChaseFact {
+        let rule = self.to_instantiated_rule();
+        let derived_atom = &rule.head()[self._position];
+        ChaseFact::from_flat_atom(derived_atom)
+    }
+
+    fn to_instantiated_string(&self) -> String {
+        self.to_instantiated_rule().to_string()
     }
 }
 
@@ -218,7 +228,7 @@ pub enum ExecutionTraceTree {
 #[derive(Debug)]
 enum TracePetGraphNodeLabel {
     Fact(ChaseFact),
-    Rule(TraceTreeRuleApplication),
+    Rule(Rule),
 }
 
 impl ExecutionTraceTree {
@@ -248,17 +258,30 @@ impl ExecutionTraceTree {
 
         let mut node_stack: Vec<(Option<NodeIndex>, Self)> = vec![(None, self.clone())];
         while let Some((parent_node_index_opt, next_node)) = node_stack.pop() {
-            let petgraph_node = match next_node {
-                Self::Fact(ref chase_fact) => TracePetGraphNodeLabel::Fact(chase_fact.clone()),
+            let next_node_index = match next_node {
+                Self::Fact(ref chase_fact) => {
+                    let next_node_index =
+                        graph.add_node(TracePetGraphNodeLabel::Fact(chase_fact.clone()));
+                    if let Some(parent_node_index) = parent_node_index_opt {
+                        graph.add_edge(next_node_index, parent_node_index, ());
+                    }
+                    next_node_index
+                }
                 Self::Rule(ref trace_tree_rule_application, _) => {
-                    TracePetGraphNodeLabel::Rule(trace_tree_rule_application.clone())
+                    let fact = trace_tree_rule_application.to_derived_fact();
+                    let rule = trace_tree_rule_application.rule.clone();
+
+                    let fact_node_index = graph.add_node(TracePetGraphNodeLabel::Fact(fact));
+                    let next_node_index = graph.add_node(TracePetGraphNodeLabel::Rule(rule));
+                    graph.add_edge(next_node_index, fact_node_index, ());
+
+                    if let Some(parent_node_index) = parent_node_index_opt {
+                        graph.add_edge(fact_node_index, parent_node_index, ());
+                    }
+
+                    next_node_index
                 }
             };
-
-            let next_node_index = graph.add_node(petgraph_node);
-            if let Some(parent_node_index) = parent_node_index_opt {
-                graph.add_edge(next_node_index, parent_node_index, ());
-            }
 
             if let Self::Rule(_, subtrees) = next_node {
                 let new_parent_node_index_opt = Some(next_node_index);
@@ -283,12 +306,9 @@ impl ExecutionTraceTree {
                     (Cow::from("type"), Cow::from("axiom")),
                     (Cow::from("element"), Cow::from(chase_fact.to_string())),
                 ],
-                TracePetGraphNodeLabel::Rule(trace_tree_rule_application) => vec![
-                    (Cow::from("type"), Cow::from("axiom")),
-                    (
-                        Cow::from("element"),
-                        Cow::from(trace_tree_rule_application.to_instantiated_string()),
-                    ),
+                TracePetGraphNodeLabel::Rule(rule) => vec![
+                    (Cow::from("type"), Cow::from("DLRule")),
+                    (Cow::from("element"), Cow::from(rule.to_string())),
                 ],
             }))
             .to_string()


### PR DESCRIPTION
This PR contains two features regarding tracing (that we also have for version `0.4.0` on the `tracing-playground` branch):
- read facts to be traced from file
- output GraphML format for trace result (required by Evonne)