### PR TITLE
Error message for arithmetic in negated literals

### DIFF
--- a/nemo/src/io/parser/types.rs
+++ b/nemo/src/io/parser/types.rs
@@ -149,6 +149,12 @@ pub enum ParseError {
     /// The variable must only depend on variables that occur in a positive body literal.
     #[error(r#"the variable "{0}" must only depend on variables that occur in a positive body literals"#)]
     UnsafeDefinition(Variable),
+    /// Negated literal uses a complex term.
+    #[error(r#"negated literal "{0}" uses the complex term "{1}""#)]
+    NegatedLiteralComplex(String, String),
+    /// Negated literal uses a derived variable.
+    #[error(r#"negated literal "{0}" uses a derived variable "{1}""#)]
+    NegatedLiteralDerived(String, Variable),
     /// Complex term uses a derived variable.
     #[error(r#"complex term "{0}" uses a derived variable "{1}""#)]
     ComplexTermDerived(String, Variable),

--- a/nemo/src/model/rule_model/rule.rs
+++ b/nemo/src/model/rule_model/rule.rs
@@ -161,19 +161,52 @@ impl Rule {
         for negative_literal in negative {
             let mut current_unsafe = HashSet::<Variable>::new();
 
-            for primitive_term in negative_literal.primitive_terms() {
-                if let PrimitiveTerm::Variable(variable) = primitive_term {
-                    if derived_variables.contains(&variable) || safe_variables.contains(variable) {
-                        continue;
-                    }
+            for negative_term in negative_literal.terms() {
+                if let Term::Primitive(primitive_term) = negative_term {
+                    if let PrimitiveTerm::Variable(variable) = primitive_term {
+                        if safe_variables.contains(variable) {
+                            continue;
+                        }
 
-                    if unsafe_negative_variables.contains(variable) {
-                        return Err(ParseError::UnsafeVariableInMultipleNegativeLiterals(
-                            variable.clone(),
-                        ));
-                    }
+                        if derived_variables.contains(variable) {
+                            return Err(ParseError::NegatedLiteralDerived(
+                                negative_literal.to_string(),
+                                variable.clone(),
+                            ));
+                        }
 
-                    current_unsafe.insert(variable.clone());
+                        if unsafe_negative_variables.contains(variable) {
+                            return Err(ParseError::UnsafeVariableInMultipleNegativeLiterals(
+                                variable.clone(),
+                            ));
+                        }
+                        if let PrimitiveTerm::Variable(variable) = primitive_term {
+                            if safe_variables.contains(variable) {
+                                continue;
+                            }
+
+                            if derived_variables.contains(variable) {
+                                return Err(ParseError::NegatedLiteralDerived(
+                                    negative_literal.to_string(),
+                                    variable.clone(),
+                                ));
+                            }
+
+                            if unsafe_negative_variables.contains(variable) {
+                                return Err(ParseError::UnsafeVariableInMultipleNegativeLiterals(
+                                    variable.clone(),
+                                ));
+                            }
+
+                            current_unsafe.insert(variable.clone());
+                        }
+                        current_unsafe.insert(variable.clone());
+                    }
+                } else {
+                    return Err(ParseError::NegatedLiteralComplex(
+                        negative_literal.to_string(),
+                        negative_term.to_string(),
+                    ));
                 }
             }
 


### PR DESCRIPTION
We do not support rules like
```
A(1).
C(3).
A(?b):-
    A(?a),
    ?b = ?a + 1,
    ~C(?b).
```
but had no error message for such case (it would just ignore it previously). 

I think we used to be able to do this, but because new terms are now only being computed after aggregates and aggregates need to happen after negation, we can't handle this any more. Needs a solution until the next (0.6.0) release.