### PR TITLE
Fix aux rule generation for existential rules

### DIFF
--- a/nemo/src/execution/rule_execution.rs
+++ b/nemo/src/execution/rule_execution.rs
@@ -76,7 +76,7 @@ impl RuleExecution {
             self.promising_variable_orders.iter().enumerate().fold(
                 "".to_string(),
                 |acc, (index, promising_order)| {
-                    format!("{}\n   ({}) {})", acc, index, promising_order.debug())
+                    format!("{}\n   ({}) {}", acc, index, promising_order.debug())
                 }
             )
         );

--- a/nemo/src/program_analysis/analysis.rs
+++ b/nemo/src/program_analysis/analysis.rs
@@ -130,9 +130,9 @@ fn construct_existential_aux_rule(
         Variable::Universal(name)
     };
 
-    let mut used_variables = HashSet::new();
     let mut aux_predicate_terms = Vec::new();
     for atom in &head_atoms {
+        let mut used_variables = HashSet::new();
         let mut new_terms = Vec::new();
 
         for term in atom.terms() {


### PR DESCRIPTION
Fixes a problem with the auxiliary rule generation for existential rules, which caused the variable order code to generate non-optimal orders.