### PR TITLE
Handle HttpResources as raw bytes, not as text

### DIFF
--- a/nemo/src/io/resource_providers/http.rs
+++ b/nemo/src/io/resource_providers/http.rs
@@ -45,7 +45,9 @@ impl Read for HttpResource {
 impl HttpResourceProvider {
     async fn get(url: &Resource) -> Result<HttpResource, ReadingError> {
         let response = reqwest::get(url).await?;
-        let content = response.text().await?;
+        // we're expecting potentially compressed data, don't try to
+        // do any character set guessing, as `response.text()` would do.
+        let content = response.bytes().await?;
 
         Ok(HttpResource {
             url: url.to_string(),


### PR DESCRIPTION
Trying to handle these as text messes with, e.g., the GZip header, leading to decompression failures.