### PR TITLE
Fix call of out-of-scope function

### DIFF
--- a/nemo-physical/src/datatypes/run_length_encodable.rs
+++ b/nemo-physical/src/datatypes/run_length_encodable.rs
@@ -1,5 +1,6 @@
 use std::{
     fmt::Debug,
+    mem::size_of,
     ops::{Add, Sub},
 };
 


### PR DESCRIPTION
### Description

I get this error during compilation:

```
error[E0425]: cannot find function `size_of` in this scope
  --> nemo-physical/src/datatypes/run_length_encodable.rs:68:21
   |
68 |         ByteSize::b(size_of::<IntStep>() as u64)
   |                     ^^^^^^^ not found in this scope
   |
help: consider importing one of these items
   |
1  + use core::mem::size_of;
   |
1  + use std::mem::size_of;
   |

error[E0425]: cannot find function `size_of` in this scope
   --> nemo-physical/src/datatypes/run_length_encodable.rs:170:21
    |
170 |         ByteSize::b(size_of::<SmallIntStep>() as u64)
    |                     ^^^^^^^ not found in this scope
    |
help: consider importing one of these items
    |
1   + use core::mem::size_of;
    |
1   + use std::mem::size_of;
    |
```

I think it originated from the commit e719833ef497367c55676d2011ca8ba86824f7fd where the full qualification of `size_of` (i.e. `std:mem`) was removed.

I am surprised no-one else is getting this error, perhaps it is my configuration? Seems highly unlikely though. 

Anyway, here is a fix that looks pretty necessary. 

### System

Model: MacBook Air 13"
OS: macOS 14.4.1
CPU: Apple M1
RAM: 8gb