### PR TITLE
Refactor loop-based unicode grapheme comparison to be slice-based

### DIFF
--- a/nemo-physical/src/function/definitions/string.rs
+++ b/nemo-physical/src/function/definitions/string.rs
@@ -157,18 +157,10 @@ impl BinaryFunction for StringStarts {
             |(first_string, second_string)| {
                 let first_graphemes = first_string.graphemes(true).collect::<Vec<&str>>();
                 let second_graphemes = second_string.graphemes(true).collect::<Vec<&str>>();
-
                 if second_graphemes.len() > first_graphemes.len() {
                     return AnyDataValue::new_boolean(false);
                 }
-
-                for i in 0..second_graphemes.len() {
-                    if first_graphemes[i] != second_graphemes[i] {
-                        return AnyDataValue::new_boolean(false);
-                    }
-                }
-
-                AnyDataValue::new_boolean(true)
+                AnyDataValue::new_boolean(first_graphemes[0..second_graphemes.len()] == second_graphemes)
             },
         )
     }
@@ -201,20 +193,10 @@ impl BinaryFunction for StringEnds {
             |(first_string, second_string)| {
                 let first_graphemes = first_string.graphemes(true).collect::<Vec<&str>>();
                 let second_graphemes = second_string.graphemes(true).collect::<Vec<&str>>();
-
                 if second_graphemes.len() > first_graphemes.len() {
                     return AnyDataValue::new_boolean(false);
                 }
-
-                for i in 0..second_graphemes.len() {
-                    if first_graphemes[first_graphemes.len() - 1 - i]
-                        != second_graphemes[second_graphemes.len() - 1 - i]
-                    {
-                        return AnyDataValue::new_boolean(false);
-                    }
-                }
-
-                AnyDataValue::new_boolean(true)
+                AnyDataValue::new_boolean(first_graphemes[first_graphemes.len() - second_graphemes.len()..] == second_graphemes)
             },
         )
     }

--- a/nemo-physical/src/function/definitions/string.rs
+++ b/nemo-physical/src/function/definitions/string.rs
@@ -160,7 +160,9 @@ impl BinaryFunction for StringStarts {
                 if second_graphemes.len() > first_graphemes.len() {
                     return AnyDataValue::new_boolean(false);
                 }
-                AnyDataValue::new_boolean(first_graphemes[0..second_graphemes.len()] == second_graphemes)
+                AnyDataValue::new_boolean(
+                    first_graphemes[0..second_graphemes.len()] == second_graphemes,
+                )
             },
         )
     }
@@ -196,7 +198,10 @@ impl BinaryFunction for StringEnds {
                 if second_graphemes.len() > first_graphemes.len() {
                     return AnyDataValue::new_boolean(false);
                 }
-                AnyDataValue::new_boolean(first_graphemes[first_graphemes.len() - second_graphemes.len()..] == second_graphemes)
+                AnyDataValue::new_boolean(
+                    first_graphemes[first_graphemes.len() - second_graphemes.len()..]
+                        == second_graphemes,
+                )
             },
         )
     }

--- a/nemo-physical/src/function/definitions/string.rs
+++ b/nemo-physical/src/function/definitions/string.rs
@@ -161,7 +161,7 @@ impl BinaryFunction for StringStarts {
                     return AnyDataValue::new_boolean(false);
                 }
                 AnyDataValue::new_boolean(
-                    first_graphemes[0..second_graphemes.len()] == second_graphemes,
+                    first_graphemes[..second_graphemes.len()] == second_graphemes,
                 )
             },
         )
@@ -233,7 +233,7 @@ impl BinaryFunction for StringBefore {
         string_pair_from_any(parameter_first, parameter_second).map(
             |(first_string, second_string)| {
                 let result = if let Some(i) = unicode_find(&first_string, &second_string) {
-                    first_string[0..i].to_string()
+                    first_string[..i].to_string()
                 } else {
                     "".to_string()
                 };


### PR DESCRIPTION
I apologise for this pedantic PR. The fact I refactored `unicode_find` to use slice-based comparison but left the loop-based comparison in `StringStarts` and `StringEnds` was really bugging me...