### PR TITLE
Add REGEX string builtin function

### DIFF
--- a/nemo-physical/src/function/definitions.rs
+++ b/nemo-physical/src/function/definitions.rs
@@ -34,7 +34,7 @@ use self::{
     },
     string::{
         StringAfter, StringBefore, StringCompare, StringConcatenation, StringContains, StringEnds,
-        StringLength, StringLowercase, StringReverse, StringStarts, StringSubstring,
+        StringLength, StringLowercase, StringRegex, StringReverse, StringStarts, StringSubstring,
         StringSubstringLength, StringUppercase,
     },
 };
@@ -231,6 +231,7 @@ pub enum BinaryFunctionEnum {
     StringBefore(StringBefore),
     StringCompare(StringCompare),
     StringContains(StringContains),
+    StringRegex(StringRegex),
     StringEnds(StringEnds),
     StringStarts(StringStarts),
     StringSubstring(StringSubstring),
@@ -256,6 +257,7 @@ impl BinaryFunction for BinaryFunctionEnum {
             Self::StringBefore(function) => function,
             Self::StringCompare(function) => function,
             Self::StringContains(function) => function,
+            Self::StringRegex(function) => function,
             Self::StringEnds(function) => function,
             Self::StringStarts(function) => function,
             Self::StringSubstring(function) => function,

--- a/nemo-physical/src/function/evaluation.rs
+++ b/nemo-physical/src/function/evaluation.rs
@@ -416,6 +416,12 @@ mod test {
         );
         evaluate_expect(&tree_not_contains, Some(AnyDataValue::new_boolean(false)));
 
+        let tree_regex = Function::string_regex(
+            Function::constant(any_string("hello")),
+            Function::constant(any_string("l+")),
+        );
+        evaluate_expect(&tree_regex, Some(AnyDataValue::new_boolean(true)));
+
         let tree_substring_length = Function::string_subtstring_length(
             Function::constant(any_string("Hello World")),
             Function::constant(AnyDataValue::new_integer_from_u64(7)),

--- a/nemo-physical/src/function/tree.rs
+++ b/nemo-physical/src/function/tree.rs
@@ -24,7 +24,7 @@ use super::{
         },
         string::{
             StringAfter, StringBefore, StringCompare, StringConcatenation, StringContains,
-            StringEnds, StringLength, StringLowercase, StringReverse, StringStarts,
+            StringEnds, StringLength, StringLowercase, StringRegex, StringReverse, StringStarts,
             StringSubstring, StringSubstringLength, StringUppercase,
         },
         BinaryFunctionEnum, NaryFunctionEnum, TernaryFunctionEnum, UnaryFunctionEnum,
@@ -672,6 +672,21 @@ where
             function: BinaryFunctionEnum::StringContains(StringContains),
             left: Box::new(text),
             right: Box::new(substring),
+        }
+    }
+
+    /// Create a tree node representing a check whether a string, or substring, matches
+    /// a pattern.
+    ///
+    /// This evaluates to `true` from the boolean value space
+    /// if the subtree `text` evaluates to a string that matches
+    /// the pattern resulting from evaluating the subtree `pattern`
+    /// and to `false` otherwise.
+    pub fn string_regex(text: Self, pattern: Self) -> Self {
+        Self::Binary {
+            function: BinaryFunctionEnum::StringRegex(StringRegex),
+            left: Box::new(text),
+            right: Box::new(pattern),
         }
     }
 

--- a/nemo/src/execution/planning/operations/term.rs
+++ b/nemo/src/execution/planning/operations/term.rs
@@ -45,6 +45,7 @@ pub(super) fn term_to_function_tree(
                 BinaryOperation::NumericLogarithm => FunctionTree::numeric_logarithm(left, right),
                 BinaryOperation::StringCompare => FunctionTree::string_compare(left, right),
                 BinaryOperation::StringContains => FunctionTree::string_contains(left, right),
+                BinaryOperation::StringRegex => FunctionTree::string_regex(left, right),
                 BinaryOperation::StringSubstring => FunctionTree::string_subtstring(left, right),
                 BinaryOperation::Equal => FunctionTree::equals(left, right),
                 BinaryOperation::Unequals => FunctionTree::unequals(left, right),

--- a/nemo/src/model/rule_model/term.rs
+++ b/nemo/src/model/rule_model/term.rs
@@ -129,8 +129,10 @@ pub enum BinaryOperation {
     NumericLessthaneq,
     /// Lexicographic comparison between strings
     StringCompare,
-    /// Check whether string is contained in another, correspondng to SPARQL function CONTAINS.
+    /// Check whether string is contained in another (SPARQL function CONTAINS)
     StringContains,
+    /// Check whether a pattern is matched within a string (SPARQL function REGEX)
+    StringRegex,
     /// String starting at some start position
     StringSubstring,
     /// First part of a string split by some other string
@@ -152,6 +154,7 @@ impl BinaryOperation {
             "POW" => Self::NumericPower,
             "COMPARE" => Self::StringCompare,
             "CONTAINS" => Self::StringContains,
+            "REGEX" => Self::StringRegex,
             "SUBSTR" => Self::StringSubstring,
             "STRSTARTS" => Self::StringStarts,
             "STRENDS" => Self::StringEnds,
@@ -174,6 +177,7 @@ impl BinaryOperation {
             Self::NumericLogarithm => "Logarithm",
             Self::StringCompare => "StringCompare",
             Self::StringContains => "CONTAINS",
+            Self::StringRegex => "REGEX",
             Self::StringSubstring => "SUBSTR",
             Self::Equal => "Equals",
             Self::Unequals => "Unequals",
@@ -209,6 +213,7 @@ impl BinaryOperation {
             | Self::NumericPower
             | Self::StringCompare
             | Self::StringContains
+            | Self::StringRegex
             | Self::StringSubstring
             | Self::StringStarts
             | Self::StringEnds

--- a/resources/testcases/arithmetic/builtins.rls
+++ b/resources/testcases/arithmetic/builtins.rls
@@ -59,6 +59,7 @@ result(datatype, ?R) :- cast(?A), ?R = DATATYPE(?A).
 result(concat, ?R) :- strings(?A, ?B), ?R = CONCAT(?A, " ", ?B).
 result(compare, ?R) :- strings(?A, ?B), ?R = 10 * COMPARE(?A, ?B).  
 result(contains, ?R) :- strings(?A, _), ?R = CONTAINS(?A, "lo").
+result(regex, ?R) :- strings(?A, _), ?R = REGEX(?A, "l+").
 result(subString, ?R) :- strings(?A, ?B), ?R = SUBSTR(?A, STRLEN(?B) / 2).  
 result(stringreverse, ?R) :- strings(?A, _), ?R = STRREV(?A).  
 result(subStringLength, ?R) :- strings(?A, _), ?R = SUBSTRING(?A, 2, 3).

--- a/resources/testcases/arithmetic/builtins/result.csv
+++ b/resources/testcases/arithmetic/builtins/result.csv
@@ -38,6 +38,7 @@ datatype,http://www.w3.org/2001/XMLSchema#double
 concat,"""Hello World"""
 compare,-10
 contains,"""true""^^<http://www.w3.org/2001/XMLSchema#boolean>"
+regex,"""true""^^<http://www.w3.org/2001/XMLSchema#boolean>"
 stringreverse,"""olleH"""
 subString,"""ello"""
 subStringLength,"""ell"""


### PR DESCRIPTION
Mirrors SPARQL ` xsd:boolean  REGEX (string literal text, simple literal pattern)` function.

I think a separate function should be created for the ternary variation
` xsd:boolean  REGEX (string literal text, simple literal pattern, simple literal flags)`
as was done for `SUBSTR` and `SUBSTRING`.