### PR TITLE
Bug/500 constant filters

### DIFF
--- a/nemo-physical/src/tabular/operations/filter.rs
+++ b/nemo-physical/src/tabular/operations/filter.rs
@@ -144,7 +144,7 @@ impl GeneratorFilter {
         let mut grouped_filters = HashMap::<OperationColumnMarker, Vec<&Filter>>::new();
 
         for filter in filters {
-            let marker = Self::find_last_reference(input, filter).unwrap_or(input[0].clone());
+            let marker = Self::find_last_reference(input, filter).unwrap_or(input[0]);
             grouped_filters.entry(marker).or_default().push(filter);
         }
 

--- a/nemo-physical/src/tabular/operations/filter.rs
+++ b/nemo-physical/src/tabular/operations/filter.rs
@@ -117,16 +117,20 @@ impl GeneratorFilter {
 
     /// Helper function that finds the [OperationColumnMarker] used in the given [Filter]
     /// that appears closest to the end of the given [OperationTable].
-    fn find_last_reference(table: &OperationTable, filter: &Filter) -> OperationColumnMarker {
+    ///
+    /// Returns `None` if the given filter does not use any values as input.
+    fn find_last_reference(
+        table: &OperationTable,
+        filter: &Filter,
+    ) -> Option<OperationColumnMarker> {
         let references = filter.references();
         for marker in table.iter().rev() {
             if references.contains(marker) {
-                return *marker;
+                return Some(*marker);
             }
         }
 
-        // Compute constant columns in the first column
-        table[0]
+        None
     }
 
     /// Helper function that takes a list of boolean [Filter]s
@@ -140,7 +144,7 @@ impl GeneratorFilter {
         let mut grouped_filters = HashMap::<OperationColumnMarker, Vec<&Filter>>::new();
 
         for filter in filters {
-            let marker = Self::find_last_reference(input, filter);
+            let marker = Self::find_last_reference(input, filter).unwrap_or(input[0].clone());
             grouped_filters.entry(marker).or_default().push(filter);
         }
 

--- a/nemo-physical/src/tabular/operations/filter.rs
+++ b/nemo-physical/src/tabular/operations/filter.rs
@@ -125,7 +125,8 @@ impl GeneratorFilter {
             }
         }
 
-        unreachable!("Filter must only use markers from the table.")
+        // Compute constant columns in the first column
+        table[0]
     }
 
     /// Helper function that takes a list of boolean [Filter]s

--- a/nemo/src/lib.rs
+++ b/nemo/src/lib.rs
@@ -1,5 +1,6 @@
 //! A fast in-memory rule engine
 
+#![type_length_limit = "40000000"]
 #![deny(
     missing_debug_implementations,
     missing_copy_implementations,

--- a/nemo/src/lib.rs
+++ b/nemo/src/lib.rs
@@ -1,6 +1,6 @@
 //! A fast in-memory rule engine
 
-#![type_length_limit = "40000000"]
+#![type_length_limit = "5000000000"]
 #![deny(
     missing_debug_implementations,
     missing_copy_implementations,

--- a/resources/testcases/regression/planning_engine/constants_filter/run.rls
+++ b/resources/testcases/regression/planning_engine/constants_filter/run.rls
@@ -1,0 +1,11 @@
+%%% Test related to 
+%%% https://github.com/knowsys/nemo/issues/500
+%%%
+%%% A panic was caused by having a filter consisting of constants
+
+pair(1, 2) .
+pair(3, 3) .
+
+equal(?x) :- pair(?x, ?y), c = d .
+
+@export equal :- csv {} .


### PR DESCRIPTION
I had code that computed the column on which a filter is going to be applied on. This depended upon the input variables, e.g. when computing `a(x, y, z), 2 * x > z`, the less-than filter should be applied on column `z` as the value for `x` has to be bound when computing the filter. The code that finds the last occurrence of a variable panicked if the filter did not contain any variable.

To fix this I simply assign constant filters to the first column.

Fixes #500.  