### PR TITLE
sync wasm-bindgen version between cargo and nix

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -36,11 +36,11 @@
     },
     "nixpkgs-unstable": {
       "locked": {
-        "lastModified": 1724479785,
-        "narHash": "sha256-pP3Azj5d6M5nmG68Fu4JqZmdGt4S4vqI5f8te+E/FTw=",
+        "lastModified": 1727634051,
+        "narHash": "sha256-S5kVU7U82LfpEukbn/ihcyNt2+EvG7Z5unsKW9H/yFA=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "d0e1602ddde669d5beb01aec49d71a51937ed7be",
+        "rev": "06cf0e1da4208d3766d898b7fdab6513366d45b9",
         "type": "github"
       },
       "original": {
@@ -65,11 +65,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1724811750,
-        "narHash": "sha256-PvhVgQ1rm3gfhK7ts4emprhh/KMkFwXogmgsQ3srR7g=",
+        "lastModified": 1727836133,
+        "narHash": "sha256-JE0zciM5IGWvK8J/pE2VldNBf7oyMH5WrU8tZArefbg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "6a1c4915dca7149e7258d8c7f3ac634d8c65f6c6",
+        "rev": "02321540b0c8000b36889b1b974d1fec585b25a4",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -25,11 +25,7 @@ rec {
       channels.nixpkgs.overlaysBuilder = channels: [
         rust-overlay.overlays.default
         (final: prev: {
-          wasm-bindgen-cli = channels.nixpkgs-unstable.wasm-bindgen-cli.override {
-            version = "0.2.93";
-            hash = "sha256-DDdu5mM3gneraM85pAepBXWn3TMofarVR4NbjMdz3r0=";
-            cargoHash = "sha256-birrg+XABBHHKJxfTKAMSlmTVYLmnmqMDfRnmG6g/YQ=";
-          };
+          inherit (channels.nixpkgs-unstable) wasm-bindgen-cli;
         })
       ];
 

--- a/flake.nix
+++ b/flake.nix
@@ -27,9 +27,9 @@ rec {
         rust-overlay.overlays.default
         (final: prev: {
           wasm-bindgen-cli = channels.nixpkgs-unstable.wasm-bindgen-cli.override {
-            version = "0.2.92";
-            hash = "sha256-1VwY8vQy7soKEgbki4LD+v259751kKxSxmo/gqE6yV0=";
-            cargoHash = "sha256-aACJ+lYNEU8FFBs158G1/JG8sc6Rq080PeKCMnwdpH0=";
+            version = "0.2.93";
+            hash = "sha256-DDdu5mM3gneraM85pAepBXWn3TMofarVR4NbjMdz3r0=";
+            cargoHash = "sha256-birrg+XABBHHKJxfTKAMSlmTVYLmnmqMDfRnmG6g/YQ=";
           };
         })
       ];

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,6 @@ rec {
     rust-overlay.url = "github:oxalica/rust-overlay";
     rust-overlay.inputs = {
       nixpkgs.follows = "nixpkgs";
-      flake-utils.follows = "utils/flake-utils";
     };
 
     utils.url = "github:gytis-ivaskevicius/flake-utils-plus";

--- a/nemo-wasm/Cargo.toml
+++ b/nemo-wasm/Cargo.toml
@@ -25,6 +25,7 @@ nemo-language-server = { path = "../nemo-language-server", features = [ "js" ], 
 futures = "0.3.21"
 gloo-utils = { version = "0.1", features = ["serde"] }
 thiserror = "1.0"
+# NOTE: the version of wasm-bindgen must be kept in sync with flake.nix
 wasm-bindgen = "=0.2.93"
 wasm-bindgen-futures = "0.4.37"
 web-sys = { version = "0.3.64", features = [ "Blob", "FileReaderSync", "FileSystemSyncAccessHandle" ]}

--- a/nemo-wasm/Cargo.toml
+++ b/nemo-wasm/Cargo.toml
@@ -25,7 +25,7 @@ nemo-language-server = { path = "../nemo-language-server", features = [ "js" ], 
 futures = "0.3.21"
 gloo-utils = { version = "0.1", features = ["serde"] }
 thiserror = "1.0"
-wasm-bindgen = "0.2"
+wasm-bindgen = "=0.2.93"
 wasm-bindgen-futures = "0.4.37"
 web-sys = { version = "0.3.64", features = [ "Blob", "FileReaderSync", "FileSystemSyncAccessHandle" ]}
 


### PR DESCRIPTION
`nix flake check` should now work again.