### PR TITLE
Bugfix/544 error in empty editor

### DIFF
--- a/nemo-language-server/src/language_server/lsp_component.rs
+++ b/nemo-language-server/src/language_server/lsp_component.rs
@@ -86,6 +86,12 @@ where
 
     fn symbol_info(&self) -> Option<LSPSymbolInfo> {
         let kind = match self.context() {
+            ParserContext::Program => {
+                return Some(LSPSymbolInfo {
+                    kind: SymbolKind::FILE,
+                    name: "Program".to_string(),
+                })
+            }
             ParserContext::Base => {
                 return Some(LSPSymbolInfo {
                     kind: SymbolKind::PROPERTY,

--- a/nemo/src/parser/span.rs
+++ b/nemo/src/parser/span.rs
@@ -124,7 +124,7 @@ impl<'a> Span<'a> {
 
         let end_offset = start.offset + self.fragment.len();
         let end_line = start.line
-            + u32::try_from(self.fragment.lines().count() - 1)
+            + u32::try_from(self.fragment.lines().count().saturating_sub(1))
                 .expect("cannot convert line number to u32");
         let end_column = if self.fragment.lines().count() > 1 {
             u32::try_from(


### PR DESCRIPTION
Fixes #544 

This version is already deployed here:
https://tools.iccl.inf.tu-dresden.de/nemo/next
Feel free to double check that the error is gone :)