### PR TITLE
Split `ExecutionEngine::execute` into smaller functions

### DIFF
--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -282,7 +282,8 @@ fn run(mut cli: CliApp) -> Result<(), CliError> {
         cli.import_directory.clone(),
     ));
 
-    let mut engine: DefaultExecutionEngine = ExecutionEngine::initialize(&program, import_manager)?;
+    let mut engine: DefaultExecutionEngine =
+        ExecutionEngine::initialize(program.clone(), import_manager)?;
 
     for (predicate, handler) in engine.exports() {
         export_manager.validate(&predicate, &*handler)?;

--- a/nemo-python/src/lib.rs
+++ b/nemo-python/src/lib.rs
@@ -398,7 +398,7 @@ impl NemoEngine {
     fn py_new(program: NemoProgram) -> PyResult<Self> {
         TimedCode::instance().reset();
         let import_manager = ImportManager::new(ResourceProviders::default());
-        let engine = ExecutionEngine::initialize(&program.0, import_manager).py_res()?;
+        let engine = ExecutionEngine::initialize(program.0.clone(), import_manager).py_res()?;
         Ok(NemoEngine { program, engine })
     }
 

--- a/nemo-wasm/src/lib.rs
+++ b/nemo-wasm/src/lib.rs
@@ -282,7 +282,7 @@ impl NemoEngine {
         };
         let import_manager = ImportManager::new(resource_providers);
 
-        let engine = ExecutionEngine::initialize(&program.0, import_manager)
+        let engine = ExecutionEngine::initialize(program.0.clone(), import_manager)
             .map_err(WasmOrInternalNemoError::Nemo)
             .map_err(NemoError)?;
 

--- a/nemo/src/api.rs
+++ b/nemo/src/api.rs
@@ -59,7 +59,7 @@ pub fn load_string(input: String) -> Result<Engine, Error> {
         .translate(&program_ast)
         .map_err(|_| Error::ProgramParseError)?;
 
-    ExecutionEngine::initialize(&program, ImportManager::new(ResourceProviders::default()))
+    ExecutionEngine::initialize(program, ImportManager::new(ResourceProviders::default()))
 }
 
 /// Executes the reasoning process of the [Engine].

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -83,8 +83,8 @@ pub struct ExecutionEngine<RuleSelectionStrategy> {
 
 impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
     /// Initialize [ExecutionEngine].
-    pub fn initialize(program: &Program, input_manager: ImportManager) -> Result<Self, Error> {
-        let chase_program = ProgramChaseTranslation::new().translate(program.clone());
+    pub fn initialize(program: Program, input_manager: ImportManager) -> Result<Self, Error> {
+        let chase_program = ProgramChaseTranslation::new().translate(program);
         let analysis = chase_program.analyze();
 
         let mut table_manager = TableManager::new();
@@ -175,6 +175,57 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
         Ok(())
     }
 
+    fn step(&mut self, rule_index: usize, execution: &RuleExecution) -> Result<Vec<Tag>, Error> {
+        let timing_string = format!("Reasoning/Rules/Rule {rule_index}");
+
+        TimedCode::instance().sub(&timing_string).start();
+        log::info!("<<< {0}: APPLYING RULE {rule_index} >>>", self.current_step);
+
+        self.rule_history.push(rule_index);
+
+        let current_info = &mut self.rule_infos[rule_index];
+
+        let updated_predicates =
+            execution.execute(&mut self.table_manager, current_info, self.current_step)?;
+
+        current_info.step_last_applied = self.current_step;
+
+        let rule_duration = TimedCode::instance().sub(&timing_string).stop();
+        log::info!("Rule duration: {} ms", rule_duration.as_millis());
+
+        self.current_step += 1;
+        Ok(updated_predicates)
+    }
+
+    fn defrag(&mut self, updated_predicates: Vec<Tag>) -> Result<(), Error> {
+        for updated_pred in updated_predicates {
+            let counter = self
+                .predicate_fragmentation
+                .entry(updated_pred.clone())
+                .or_insert(0);
+            *counter += 1;
+
+            if *counter == MAX_FRAGMENTATION {
+                let start = if let Some(last_union) = self.predicate_last_union.get(&updated_pred) {
+                    last_union + 1
+                } else {
+                    0
+                };
+
+                let range = start..(self.current_step + 1);
+
+                self.table_manager.combine_tables(&updated_pred, range)?;
+
+                self.predicate_last_union
+                    .insert(updated_pred, self.current_step);
+
+                *counter = 0;
+            }
+        }
+
+        Ok(())
+    }
+
     /// Executes the program.
     pub fn execute(&mut self) -> Result<(), Error> {
         TimedCode::instance().sub("Reasoning/Rules").start();
@@ -190,61 +241,11 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
         let mut new_derivations: Option<bool> = None;
 
-        while let Some(current_rule_index) = self.rule_strategy.next_rule(new_derivations) {
-            let timing_string = format!("Reasoning/Rules/Rule {current_rule_index}");
-
-            TimedCode::instance().sub(&timing_string).start();
-            log::info!(
-                "<<< {0}: APPLYING RULE {current_rule_index} >>>",
-                self.current_step
-            );
-
-            self.rule_history.push(current_rule_index);
-
-            let current_info = &mut self.rule_infos[current_rule_index];
-            let current_execution = &rule_execution[current_rule_index];
-
-            let updated_predicates = current_execution.execute(
-                &mut self.table_manager,
-                current_info,
-                self.current_step,
-            )?;
-
+        while let Some(index) = self.rule_strategy.next_rule(new_derivations) {
+            let updated_predicates = self.step(index, &rule_execution[index])?;
             new_derivations = Some(!updated_predicates.is_empty());
 
-            current_info.step_last_applied = self.current_step;
-
-            let rule_duration = TimedCode::instance().sub(&timing_string).stop();
-            log::info!("Rule duration: {} ms", rule_duration.as_millis());
-
-            // We prevent fragmentation by periodically collecting single-step tables into larger ones
-            for updated_pred in updated_predicates {
-                let counter = self
-                    .predicate_fragmentation
-                    .entry(updated_pred.clone())
-                    .or_insert(0);
-                *counter += 1;
-
-                if *counter == MAX_FRAGMENTATION {
-                    let start =
-                        if let Some(last_union) = self.predicate_last_union.get(&updated_pred) {
-                            last_union + 1
-                        } else {
-                            0
-                        };
-
-                    let range = start..(self.current_step + 1);
-
-                    self.table_manager.combine_tables(&updated_pred, range)?;
-
-                    self.predicate_last_union
-                        .insert(updated_pred, self.current_step);
-
-                    *counter = 0;
-                }
-            }
-
-            self.current_step += 1;
+            self.defrag(updated_predicates)?;
         }
 
         TimedCode::instance().sub("Reasoning/Rules").stop();


### PR DESCRIPTION
note: based on #548

Rule execution is now performed in `ExecutionEngine::step`, which returns a `Vec` of the changed predicates. De fragmentation of tables is performed separately in `ExecutionEngine::defrag`.

Also `ExectionEngine::initialize` takes ownership of its `Program` parameter instead of taking a reference and then cloning it, which is just bad practice.

Finally the odd `ChaseProgram` parameter, which was handed down to the tracing functions is removed, by being a bit more conscious about where and what to clone. Note that this will likely change later, as I'm cleaning up more of the tracing code.