### PR TITLE
add builtin functions BITSHL, BITSHR, BITSHRU

### DIFF
--- a/nemo-physical/src/function/definitions.rs
+++ b/nemo-physical/src/function/definitions.rs
@@ -26,9 +26,10 @@ use self::{
     generic::{CanonicalString, Datatype, Equals, LexicalValue, Unequals},
     language::LanguageTag,
     numeric::{
-        BitAnd, BitOr, BitXor, NumericAbsolute, NumericAddition, NumericCeil, NumericCosine,
-        NumericDivision, NumericFloor, NumericGreaterthan, NumericGreaterthaneq, NumericLessthan,
-        NumericLessthaneq, NumericLogarithm, NumericLukasiewicz, NumericMaximum, NumericMinimum,
+        BitAnd, BitOr, BitShiftLeft, BitShiftRight, BitShiftRightUnsigned, BitXor, NumericAbsolute,
+        NumericAddition, NumericCeil, NumericCosine, NumericDivision, NumericFloor,
+        NumericGreaterthan, NumericGreaterthaneq, NumericLessthan, NumericLessthaneq,
+        NumericLogarithm, NumericLukasiewicz, NumericMaximum, NumericMinimum,
         NumericMultiplication, NumericNegation, NumericPower, NumericProduct, NumericRemainder,
         NumericRound, NumericSine, NumericSquareroot, NumericSubtraction, NumericSum,
         NumericTangent,
@@ -242,6 +243,9 @@ pub enum BinaryFunctionEnum {
     StringEnds(StringEnds),
     StringStarts(StringStarts),
     StringSubstring(StringSubstring),
+    BitShiftLeft(BitShiftLeft),
+    BitShiftRight(BitShiftRight),
+    BitShiftRightUnsigned(BitShiftRightUnsigned),
 }
 
 impl BinaryFunction for BinaryFunctionEnum {
@@ -268,6 +272,9 @@ impl BinaryFunction for BinaryFunctionEnum {
             Self::StringEnds(function) => function,
             Self::StringStarts(function) => function,
             Self::StringSubstring(function) => function,
+            Self::BitShiftLeft(function) => function,
+            Self::BitShiftRightUnsigned(function) => function,
+            Self::BitShiftRight(function) => function,
         } {
             fn evaluate(&self, first_parameter: AnyDataValue, second_parameter: AnyDataValue) -> Option<AnyDataValue>;
             fn type_propagation(&self) -> FunctionTypePropagation;

--- a/nemo-physical/src/function/definitions/numeric.rs
+++ b/nemo-physical/src/function/definitions/numeric.rs
@@ -512,10 +512,10 @@ impl BinaryFunction for BitShiftLeft {
         parameter_second: AnyDataValue,
     ) -> Option<AnyDataValue> {
         if let Some(pair) = NumericPair::from_any_pair_cast(&parameter_first, &parameter_second) {
-            return match pair {
+            match pair {
                 NumericPair::Integer(value, base) => numeric_bitwise_shl(value, base),
                 _ => None,
-            };
+            }
         } else {
             None
         }
@@ -537,10 +537,10 @@ impl BinaryFunction for BitShiftRight {
         parameter_second: AnyDataValue,
     ) -> Option<AnyDataValue> {
         if let Some(pair) = NumericPair::from_any_pair_cast(&parameter_first, &parameter_second) {
-            return match pair {
+            match pair {
                 NumericPair::Integer(value, base) => numeric_bitwise_shr(value, base),
                 _ => None,
-            };
+            }
         } else {
             None
         }
@@ -562,10 +562,10 @@ impl BinaryFunction for BitShiftRightUnsigned {
         parameter_second: AnyDataValue,
     ) -> Option<AnyDataValue> {
         if let Some(pair) = NumericPair::from_any_pair_cast(&parameter_first, &parameter_second) {
-            return match pair {
+            match pair {
                 NumericPair::Integer(value, base) => numeric_bitwise_shru(value, base),
                 _ => None,
-            };
+            }
         } else {
             None
         }

--- a/nemo-physical/src/function/definitions/numeric.rs
+++ b/nemo-physical/src/function/definitions/numeric.rs
@@ -511,15 +511,12 @@ impl BinaryFunction for BitShiftLeft {
         parameter_first: AnyDataValue,
         parameter_second: AnyDataValue,
     ) -> Option<AnyDataValue> {
-        if let Some(pair) = NumericPair::from_any_pair_cast(&parameter_first, &parameter_second) {
-            match pair {
-                NumericPair::Integer(value, base) => numeric_bitwise_shl(value, base),
-                _ => None,
-            }
-        } else {
-            None
+        match NumericPair::from_any_pair_cast(&parameter_first, &parameter_second)? {
+            NumericPair::Integer(value, base) => numeric_bitwise_shl(value, base),
+            _ => None,
         }
     }
+
     fn type_propagation(&self) -> FunctionTypePropagation {
         FunctionTypePropagation::KnownOutput(StorageTypeName::Int64.bitset())
     }
@@ -536,15 +533,12 @@ impl BinaryFunction for BitShiftRight {
         parameter_first: AnyDataValue,
         parameter_second: AnyDataValue,
     ) -> Option<AnyDataValue> {
-        if let Some(pair) = NumericPair::from_any_pair_cast(&parameter_first, &parameter_second) {
-            match pair {
-                NumericPair::Integer(value, base) => numeric_bitwise_shr(value, base),
-                _ => None,
-            }
-        } else {
-            None
+        match NumericPair::from_any_pair_cast(&parameter_first, &parameter_second)? {
+            NumericPair::Integer(value, base) => numeric_bitwise_shr(value, base),
+            _ => None,
         }
     }
+
     fn type_propagation(&self) -> FunctionTypePropagation {
         FunctionTypePropagation::KnownOutput(StorageTypeName::Int64.bitset())
     }
@@ -561,15 +555,12 @@ impl BinaryFunction for BitShiftRightUnsigned {
         parameter_first: AnyDataValue,
         parameter_second: AnyDataValue,
     ) -> Option<AnyDataValue> {
-        if let Some(pair) = NumericPair::from_any_pair_cast(&parameter_first, &parameter_second) {
-            match pair {
-                NumericPair::Integer(value, base) => numeric_bitwise_shru(value, base),
-                _ => None,
-            }
-        } else {
-            None
+        match NumericPair::from_any_pair_cast(&parameter_first, &parameter_second)? {
+            NumericPair::Integer(value, base) => numeric_bitwise_shru(value, base),
+            _ => None,
         }
     }
+
     fn type_propagation(&self) -> FunctionTypePropagation {
         FunctionTypePropagation::KnownOutput(StorageTypeName::Int64.bitset())
     }

--- a/nemo-physical/src/function/definitions/numeric.rs
+++ b/nemo-physical/src/function/definitions/numeric.rs
@@ -34,12 +34,13 @@ use self::{
     },
     integer64::{
         numeric_absolute_integer64, numeric_addition_integer64, numeric_bitwise_and,
-        numeric_bitwise_or, numeric_bitwise_xor, numeric_division_integer64,
-        numeric_greaterthan_integer64, numeric_greaterthaneq_integer64, numeric_lessthan_integer64,
-        numeric_lessthaneq_integer64, numeric_logarithm_integer64, numeric_maximum_integer64,
-        numeric_minimum_integer64, numeric_multiplication_integer64, numeric_negation_integer64,
-        numeric_power_integer64, numeric_product_integer64, numeric_remainder_integer64,
-        numeric_squareroot_integer64, numeric_subtraction_integer64, numeric_sum_integer64,
+        numeric_bitwise_or, numeric_bitwise_shl, numeric_bitwise_shr, numeric_bitwise_shru,
+        numeric_bitwise_xor, numeric_division_integer64, numeric_greaterthan_integer64,
+        numeric_greaterthaneq_integer64, numeric_lessthan_integer64, numeric_lessthaneq_integer64,
+        numeric_logarithm_integer64, numeric_maximum_integer64, numeric_minimum_integer64,
+        numeric_multiplication_integer64, numeric_negation_integer64, numeric_power_integer64,
+        numeric_product_integer64, numeric_remainder_integer64, numeric_squareroot_integer64,
+        numeric_subtraction_integer64, numeric_sum_integer64,
     },
 };
 
@@ -494,6 +495,81 @@ impl NaryFunction for BitXor {
         }
     }
 
+    fn type_propagation(&self) -> FunctionTypePropagation {
+        FunctionTypePropagation::KnownOutput(StorageTypeName::Int64.bitset())
+    }
+}
+
+/// Bitwise Left shift
+///
+/// Returns `None` if the input parameter pair are not integers or no input parameters are given.
+#[derive(Debug, Copy, Clone)]
+pub struct BitShiftLeft;
+impl BinaryFunction for BitShiftLeft {
+    fn evaluate(
+        &self,
+        parameter_first: AnyDataValue,
+        parameter_second: AnyDataValue,
+    ) -> Option<AnyDataValue> {
+        if let Some(pair) = NumericPair::from_any_pair_cast(&parameter_first, &parameter_second) {
+            return match pair {
+                NumericPair::Integer(value, base) => numeric_bitwise_shl(value, base),
+                _ => None,
+            };
+        } else {
+            None
+        }
+    }
+    fn type_propagation(&self) -> FunctionTypePropagation {
+        FunctionTypePropagation::KnownOutput(StorageTypeName::Int64.bitset())
+    }
+}
+
+/// Bitwise arithmetic right shift
+///
+/// Returns `None` if the input parameter pair are not integers or no input parameters are given.
+#[derive(Debug, Copy, Clone)]
+pub struct BitShiftRight;
+impl BinaryFunction for BitShiftRight {
+    fn evaluate(
+        &self,
+        parameter_first: AnyDataValue,
+        parameter_second: AnyDataValue,
+    ) -> Option<AnyDataValue> {
+        if let Some(pair) = NumericPair::from_any_pair_cast(&parameter_first, &parameter_second) {
+            return match pair {
+                NumericPair::Integer(value, base) => numeric_bitwise_shr(value, base),
+                _ => None,
+            };
+        } else {
+            None
+        }
+    }
+    fn type_propagation(&self) -> FunctionTypePropagation {
+        FunctionTypePropagation::KnownOutput(StorageTypeName::Int64.bitset())
+    }
+}
+
+/// Bitwise logical (unsigned) right shift
+///
+/// Returns `None` if the input parameter pair are not integers or no input parameters are given.
+#[derive(Debug, Copy, Clone)]
+pub struct BitShiftRightUnsigned;
+impl BinaryFunction for BitShiftRightUnsigned {
+    fn evaluate(
+        &self,
+        parameter_first: AnyDataValue,
+        parameter_second: AnyDataValue,
+    ) -> Option<AnyDataValue> {
+        if let Some(pair) = NumericPair::from_any_pair_cast(&parameter_first, &parameter_second) {
+            return match pair {
+                NumericPair::Integer(value, base) => numeric_bitwise_shru(value, base),
+                _ => None,
+            };
+        } else {
+            None
+        }
+    }
     fn type_propagation(&self) -> FunctionTypePropagation {
         FunctionTypePropagation::KnownOutput(StorageTypeName::Int64.bitset())
     }

--- a/nemo-physical/src/function/definitions/numeric/integer64.rs
+++ b/nemo-physical/src/function/definitions/numeric/integer64.rs
@@ -210,6 +210,51 @@ pub(super) fn numeric_bitwise_xor(parameters: &[i64]) -> Option<AnyDataValue> {
     Some(AnyDataValue::new_integer_from_i64(result))
 }
 
+/// Left shift of 64-bit integer 'value' by 'base'-bits
+///
+/// Return 'None' if base is negative
+pub(super) fn numeric_bitwise_shl(value: i64, base: i64) -> Option<AnyDataValue> {
+    if base < 0 {
+        return None;
+    }
+
+    Some(AnyDataValue::new_integer_from_i64(value << base))
+}
+
+/// Right shift of 64-bit integer 'value' by 'base'-bits
+///
+/// Arithmetic right shift preserves the sign-bit of the binary representation
+///
+/// Return 'None' if base is negative
+pub(super) fn numeric_bitwise_shr(value: i64, base: i64) -> Option<AnyDataValue> {
+    if base < 0 {
+        return None;
+    }
+
+    Some(AnyDataValue::new_integer_from_i64(value >> base))
+}
+
+/// Right shift of 64-bit integer 'value' by 'base'-bits
+///
+/// Logical right shift does not preserve the sign-bit of the binary representation
+///
+/// Return 'None' if base is negative
+pub(super) fn numeric_bitwise_shru(value: i64, base: i64) -> Option<AnyDataValue> {
+    if base < 0 {
+        return None;
+    }
+
+    // Apply arithmetic right shift, if value is positive
+    let result: i64 = if value > 0 {
+        value >> base
+    } else {
+        // Convert value in unsigned to do unsigned right shift
+        (value as u64 >> base) as i64
+    };
+
+    Some(AnyDataValue::new_integer_from_i64(result))
+}
+
 /// Return the sum of the given 64-bit integers.
 ///
 /// Returns `None` if the result (or a intermediate result) does not fit into a 64-bit integer.

--- a/nemo-physical/src/function/definitions/numeric/integer64.rs
+++ b/nemo-physical/src/function/definitions/numeric/integer64.rs
@@ -248,9 +248,11 @@ pub(super) fn numeric_bitwise_shru(value: i64, base: i64) -> Option<AnyDataValue
     let result: i64 = if value > 0 {
         value >> base
     } else {
-        // Convert value in unsigned to do unsigned right shift
-        let x = value as u64 >> base;
-        x.try_into().unwrap()
+        // Convert value in unsigned to do an unsigned right shift
+        let unsigned_value = u64::from_ne_bytes(value.to_ne_bytes());
+        let unsigned_result = unsigned_value >> base;
+
+        i64::from_ne_bytes(unsigned_result.to_ne_bytes())
     };
 
     Some(AnyDataValue::new_integer_from_i64(result))

--- a/nemo-physical/src/function/definitions/numeric/integer64.rs
+++ b/nemo-physical/src/function/definitions/numeric/integer64.rs
@@ -249,7 +249,8 @@ pub(super) fn numeric_bitwise_shru(value: i64, base: i64) -> Option<AnyDataValue
         value >> base
     } else {
         // Convert value in unsigned to do unsigned right shift
-        (value as u64 >> base) as i64
+        let x = value as u64 >> base;
+        x.try_into().unwrap()
     };
 
     Some(AnyDataValue::new_integer_from_i64(result))

--- a/nemo-physical/src/function/tree.rs
+++ b/nemo-physical/src/function/tree.rs
@@ -15,12 +15,13 @@ use super::{
         generic::{CanonicalString, Datatype, Equals, LexicalValue, Unequals},
         language::LanguageTag,
         numeric::{
-            BitAnd, BitOr, BitXor, NumericAbsolute, NumericAddition, NumericCeil, NumericCosine,
-            NumericDivision, NumericFloor, NumericGreaterthan, NumericGreaterthaneq,
-            NumericLessthan, NumericLessthaneq, NumericLogarithm, NumericLukasiewicz,
-            NumericMaximum, NumericMinimum, NumericMultiplication, NumericNegation, NumericPower,
-            NumericProduct, NumericRemainder, NumericRound, NumericSine, NumericSquareroot,
-            NumericSubtraction, NumericSum, NumericTangent,
+            BitAnd, BitOr, BitShiftLeft, BitShiftRight, BitShiftRightUnsigned, BitXor,
+            NumericAbsolute, NumericAddition, NumericCeil, NumericCosine, NumericDivision,
+            NumericFloor, NumericGreaterthan, NumericGreaterthaneq, NumericLessthan,
+            NumericLessthaneq, NumericLogarithm, NumericLukasiewicz, NumericMaximum,
+            NumericMinimum, NumericMultiplication, NumericNegation, NumericPower, NumericProduct,
+            NumericRemainder, NumericRound, NumericSine, NumericSquareroot, NumericSubtraction,
+            NumericSum, NumericTangent,
         },
         string::{
             StringAfter, StringBefore, StringCompare, StringConcatenation, StringContains,
@@ -834,6 +835,34 @@ where
             }
         } else {
             parameters.remove(0)
+        }
+    }
+
+    /// Create a tree node representing the bitwise aritmetic left shift operation
+    ///
+    /// Evaluates to an integer resulting from performing the bitwise left shift operation
+    /// on the binary representation of its integer subnodes.
+    pub fn bit_shl(left: Self, right: Self) -> Self {
+        Self::Binary {
+            function: BinaryFunctionEnum::BitShiftLeft(BitShiftLeft),
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+    /// Needs documentation
+    pub fn bit_shru(left: Self, right: Self) -> Self {
+        Self::Binary {
+            function: BinaryFunctionEnum::BitShiftRightUnsigned(BitShiftRightUnsigned),
+            left: Box::new(left),
+            right: Box::new(right),
+        }
+    }
+
+    pub fn bit_shr(left: Self, right: Self) -> Self {
+        Self::Binary {
+            function: BinaryFunctionEnum::BitShiftRight(BitShiftRight),
+            left: Box::new(left),
+            right: Box::new(right),
         }
     }
 

--- a/nemo-physical/src/function/tree.rs
+++ b/nemo-physical/src/function/tree.rs
@@ -838,10 +838,11 @@ where
         }
     }
 
-    /// Create a tree node representing the bitwise aritmetic left shift operation
+    /// Create a tree node representing the bitwise left shift operation
     ///
-    /// Evaluates to an integer resulting from performing the bitwise left shift operation
-    /// on the binary representation of its integer subnodes.
+    /// This evaluates to an integer resulting from performing the bitwise left shift
+    /// The binary representation of the integer subnode 'left' is shifted
+    /// according to the integer value of the subnode 'right'
     pub fn bit_shl(left: Self, right: Self) -> Self {
         Self::Binary {
             function: BinaryFunctionEnum::BitShiftLeft(BitShiftLeft),
@@ -849,7 +850,12 @@ where
             right: Box::new(right),
         }
     }
-    /// Needs documentation
+
+    /// Create a tree node representing the bitwise unsigned right shift operation
+    ///
+    /// Evaluates to an integer resulting from performing the bitwise unsigned right shift
+    /// The binary representation of the integer subnode 'left' is shifted
+    /// according to the integer value of the subnode 'right'
     pub fn bit_shru(left: Self, right: Self) -> Self {
         Self::Binary {
             function: BinaryFunctionEnum::BitShiftRightUnsigned(BitShiftRightUnsigned),
@@ -858,6 +864,11 @@ where
         }
     }
 
+    /// Create a tree node representing the bitwise right shift operation
+    ///
+    /// Evaluates to an integer resulting from performing the bitwise right shift
+    /// The binary representation of the integer subnode 'left' is shifted
+    /// according to the integer value of the subnode 'right'
     pub fn bit_shr(left: Self, right: Self) -> Self {
         Self::Binary {
             function: BinaryFunctionEnum::BitShiftRight(BitShiftRight),

--- a/nemo/src/execution/planning/operations/operation.rs
+++ b/nemo/src/execution/planning/operations/operation.rs
@@ -85,6 +85,9 @@ pub(crate) fn operation_to_function_tree(
         OperationKind::StringStarts => binary!(string_starts, sub),
         OperationKind::StringEnds => binary!(string_ends, sub),
         OperationKind::StringRegex => binary!(string_regex, sub),
+        OperationKind::BitShl => binary!(bit_shl, sub),
+        OperationKind::BitShru => binary!(bit_shru, sub),
+        OperationKind::BitShr => binary!(bit_shr, sub),
         OperationKind::StringSubstring => {
             if sub.len() == 2 {
                 let start = sub.pop().expect("length must be 2");

--- a/nemo/src/rule_model/components/term/operation/operation_kind.rs
+++ b/nemo/src/rule_model/components/term/operation/operation_kind.rs
@@ -341,6 +341,21 @@ pub enum OperationKind {
     #[assoc(num_arguments = OperationNumArguments::Arbitrary)]
     #[assoc(return_type = ValueType::Number)]
     BitXor,
+    /// Perform left arithmetic shift
+    #[assoc(name = function::BITSHL)]
+    #[assoc(num_arguments = OperationNumArguments::Binary)]
+    #[assoc(return_type = ValueType::Number)]
+    BitShl,
+    /// Perform right unsigned (logical) shift
+    #[assoc(name = function::BITSHRU)]
+    #[assoc(num_arguments = OperationNumArguments::Binary)]
+    #[assoc(return_type = ValueType::Number)]
+    BitShru,
+    /// Perform right arithmetic shift
+    #[assoc(name = function::BITSHR)]
+    #[assoc(num_arguments = OperationNumArguments::Binary)]
+    #[assoc(return_type = ValueType::Number)]
+    BitShr,
     /// Conjunction of boolean values
     #[assoc(name = function::AND)]
     #[assoc(num_arguments = OperationNumArguments::Arbitrary)]

--- a/nemo/src/syntax.rs
+++ b/nemo/src/syntax.rs
@@ -294,6 +294,12 @@ pub mod builtin {
         pub(crate) const BITOR: &str = "BITOR";
         /// Compute the exclusive or on the bit representation of integer values
         pub(crate) const BITXOR: &str = "BITXOR";
+        /// Compute the arithmetic bit shift left for integer values
+        pub(crate) const BITSHL: &str = "BITSHL";
+        /// Compute the unsigned bit shift right for integer values
+        pub(crate) const BITSHRU: &str = "BITSHRU";
+        /// Compute the arithmetic bit shift right for integer values
+        pub(crate) const BITSHR: &str = "BITSHR";
         /// Compute the maximum of numeric values
         pub(crate) const MAX: &str = "MAX";
         /// Compute the minimum of numeric values

--- a/resources/testcases/arithmetic/builtins.rls
+++ b/resources/testcases/arithmetic/builtins.rls
@@ -96,6 +96,7 @@ result(Boolean, ?R) :- boolean(?True, ?False), ?R = STR(OR(AND(?True, ?False, ?T
 result(bitshl, ?R) :- integers(?A, ?B, _), ?R = BITSHL(?A, ?B).
 result(bitshr, ?R) :- integers(?A, ?B, _), ?R = BITSHR(?A, ?B).
 result(bitshru, ?R) :- integers(?A, ?B, _), ?C = -1 * ?A, ?R = BITSHRU(?C, ?B).
+result(bitshru, ?R) :- integers(?A, ?B, _), ?R = BITSHRU(-9223372036854775808, 0).
 
 % Nary functions
 result(sum, ?R) :- doubles(?A, ?B, ?C), ?R = SUM(?A, ?B, ?C).

--- a/resources/testcases/arithmetic/builtins.rls
+++ b/resources/testcases/arithmetic/builtins.rls
@@ -92,6 +92,11 @@ result(remainder, ?R) :- integers(_, ?A, ?B), ?R = REM(?B, ?A).
 boolean("true"^^<http://www.w3.org/2001/XMLSchema#boolean>, "false"^^<http://www.w3.org/2001/XMLSchema#boolean>).
 result(Boolean, ?R) :- boolean(?True, ?False), ?R = STR(OR(AND(?True, ?False, ?True), AND(?True, NOT(?False), NOT(NOT(?True))))).
 
+% Bitwise shift functions
+result(bitshl, ?R) :- integers(?A, ?B, _), ?R = BITSHL(?A, ?B).
+result(bitshr, ?R) :- integers(?A, ?B, _), ?R = BITSHR(?A, ?B).
+result(bitshru, ?R) :- integers(?A, ?B, _), ?C = -1 * ?A, ?R = BITSHRU(?C, ?B).
+
 % Nary functions
 result(sum, ?R) :- doubles(?A, ?B, ?C), ?R = SUM(?A, ?B, ?C).
 result(prod, ?R) :- doubles(?A, ?B, ?C), ?R = PRODUCT(?A, ?B, ?C).

--- a/resources/testcases/arithmetic/builtins/result.csv
+++ b/resources/testcases/arithmetic/builtins/result.csv
@@ -67,3 +67,6 @@ fstring_basic,"""Hello and World"""
 fstring_arithmetic,"""len*10=50"""
 fstring_multiline,"""Hello and World"""
 uriencode,"""%3Ffoo%5B%5D%3D%22bar%20quuz%22"""
+bitshl,4
+bitshr,0
+bitshru,4611686018427387903

--- a/resources/testcases/arithmetic/builtins/result.csv
+++ b/resources/testcases/arithmetic/builtins/result.csv
@@ -70,3 +70,4 @@ uriencode,"""%3Ffoo%5B%5D%3D%22bar%20quuz%22"""
 bitshl,4
 bitshr,0
 bitshru,4611686018427387903
+bitshru,-9223372036854775808


### PR DESCRIPTION
All 3 functions take `(value,base)` as arguments. If `base` is negative, all functions will return `None` since negative shifts are not supported.

- `BITSHR` is the arithmetic right shift, meaning that the negation sign is kept (insert `1` as Most Significant Bit if number is negative, insert `0` if number is positive). 
- `BITSHRU` is the logical right shift, meaning that the negation sign is not kept (always insert `0` as Most Significant Bit).
- `BITSHL` shifts left by inserting `0`  as Least Significant Bit