### PR TITLE
External variables

### DIFF
--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -190,7 +190,7 @@ impl clap::builder::TypedValueParser for ParamKeyValueParser {
             return Err(clap::Error::new(clap::error::ErrorKind::InvalidValue));
         };
 
-        let Ok(value) = GroundTerm::parse(&value) else {
+        let Ok(value) = GroundTerm::parse(value) else {
             todo!()
         };
 

--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -187,11 +187,11 @@ impl clap::builder::TypedValueParser for ParamKeyValueParser {
         let inner = clap::builder::StringValueParser::new();
         let val = inner.parse_ref(cmd, arg, value)?;
         let Some((key, value)) = val.split_once('=') else {
-            return Err(clap::Error::new(clap::error::ErrorKind::InvalidValue));
+            return Err(clap::Error::new(clap::error::ErrorKind::InvalidValue).with_cmd(cmd));
         };
 
         let Ok(value) = GroundTerm::parse(value) else {
-            todo!()
+            return Err(clap::Error::new(clap::error::ErrorKind::InvalidValue).with_cmd(cmd));
         };
 
         Ok(ParamKeyValue {

--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -259,6 +259,7 @@ fn run(mut cli: CliApp) -> Result<(), CliError> {
         program_filename.clone(),
     );
 
+    // do not move out of cli.parameters, since cli is needed in call to handle_tracing
     for ParamKeyValue { key, value } in cli.parameters.drain(..) {
         translation.add_parameter(key, value);
     }

--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -25,7 +25,7 @@ use std::fs::{read_to_string, File};
 use clap::Parser;
 use colored::Colorize;
 
-use cli::{CliApp, Exporting, Reporting};
+use cli::{CliApp, Exporting, ParamKeyValue, Reporting};
 
 use error::CliError;
 use nemo::{
@@ -254,12 +254,16 @@ fn run(mut cli: CliApp) -> Result<(), CliError> {
         }
     };
 
-    let mut program = match rule_model::translation::ASTProgramTranslation::initialize(
+    let mut translation = rule_model::translation::ASTProgramTranslation::initialize(
         &program_content,
         program_filename.clone(),
-    )
-    .translate(&program_ast)
-    {
+    );
+
+    for ParamKeyValue { key, value } in cli.parameters.drain(..) {
+        translation.add_parameter(key, value);
+    }
+
+    let mut program = match translation.translate(&program_ast) {
         Ok(program) => program,
         Err(report) => {
             report.eprint()?;

--- a/nemo/src/parser/ast/rule.rs
+++ b/nemo/src/parser/ast/rule.rs
@@ -1,9 +1,6 @@
 //! This module defines [Rule].
 
-use nom::{
-    multi::many0,
-    sequence::{separated_pair, tuple},
-};
+use nom::sequence::{separated_pair, tuple};
 
 use crate::parser::{
     context::{context, ParserContext},
@@ -12,19 +9,13 @@ use crate::parser::{
     ParserResult,
 };
 
-use super::{
-    attribute::Attribute, comment::wsoc::WSoC, guard::Guard, sequence::Sequence, token::Token,
-    ProgramAST,
-};
+use super::{comment::wsoc::WSoC, guard::Guard, sequence::Sequence, token::Token, ProgramAST};
 
 /// A rule describing a logical implication
 #[derive(Debug)]
 pub struct Rule<'a> {
     /// [Span] associated with this node
     span: Span<'a>,
-
-    /// Attributes attached to this rule
-    attributes: Vec<Attribute<'a>>,
 
     /// Head of the rule
     head: Sequence<'a, Guard<'a>>,
@@ -41,11 +32,6 @@ impl<'a> Rule<'a> {
     /// Return an iterator of the [Guard]s contained in the body.
     pub fn body(&self) -> impl Iterator<Item = &Guard<'a>> {
         self.body.iter()
-    }
-
-    /// Return an iterator over the [Attribute]s attached to this rule.
-    pub fn attributes(&self) -> impl Iterator<Item = &Attribute<'a>> {
-        self.attributes.iter()
     }
 }
 
@@ -74,23 +60,19 @@ impl<'a> ProgramAST<'a> for Rule<'a> {
 
         context(
             CONTEXT,
-            tuple((
-                many0(Attribute::parse),
-                (separated_pair(
-                    Sequence::<Guard>::parse,
-                    tuple((WSoC::parse, Token::rule_arrow, WSoC::parse)),
-                    Sequence::<Guard>::parse,
-                )),
-            )),
+            separated_pair(
+                Sequence::<Guard>::parse,
+                tuple((WSoC::parse, Token::rule_arrow, WSoC::parse)),
+                Sequence::<Guard>::parse,
+            ),
         )(input)
-        .map(|(rest, (attributes, (head, body)))| {
+        .map(|(rest, (head, body))| {
             let rest_span = rest.span;
 
             (
                 rest,
                 Self {
                     span: input_span.until_rest(&rest_span),
-                    attributes,
                     head,
                     body,
                 },

--- a/nemo/src/parser/ast/rule.rs
+++ b/nemo/src/parser/ast/rule.rs
@@ -100,7 +100,7 @@ mod test {
         let test = vec![
             ("a(?x, ?y) :- b(?x, ?y)", (1, 1)),
             ("a(?x,?y), d(1), c(1) :- b(?x, ?y), c(1, 2)", (3, 2)),
-            ("#[name(\"test\")]\nresult(?x) :- test(?x)", (1, 1)),
+            ("result(?x) :- test(?x)", (1, 1)),
         ];
 
         for (input, expected) in test {

--- a/nemo/src/parser/ast/statement.rs
+++ b/nemo/src/parser/ast/statement.rs
@@ -120,6 +120,7 @@ impl<'a> ProgramAST<'a> for Statement<'a> {
             CONTEXT,
             tuple((
                 opt(DocComment::parse),
+                WSoC::parse,
                 many0(Attribute::parse),
                 delimited(
                     WSoC::parse,
@@ -128,7 +129,7 @@ impl<'a> ProgramAST<'a> for Statement<'a> {
                 ),
             )),
         )(input)
-        .map(|(rest, (comment, attributes, statement))| {
+        .map(|(rest, (comment, _, attributes, statement))| {
             let rest_span = rest.span;
 
             (
@@ -167,7 +168,7 @@ mod test {
                 ParserContext::Guard,
             ),
             (
-                "%%% A fact\n%%% with a multiline doc comment. \n#[external(?x)] \n a(1, ?x) .",
+                "%%% A fact\n%%% with a multiline doc comment. \n #[external(?x)] \n a(1, ?x) .",
                 ParserContext::Guard,
             ),
             (

--- a/nemo/src/parser/ast/statement.rs
+++ b/nemo/src/parser/ast/statement.rs
@@ -166,9 +166,21 @@ mod test {
                 "%%% A fact\n%%% with a multiline doc comment. \n a(1, 2) .",
                 ParserContext::Guard,
             ),
+            (
+                "%%% A fact\n%%% with a multiline doc comment. \n#[external(?x)] \n a(1, ?x) .",
+                ParserContext::Guard,
+            ),
+            (
+                "%%% A rule \n#[name(\"test\")] \n a(1, 2) :- b(2, 1) .",
+                ParserContext::Rule,
+            ),
             ("%%% A rule \n a(1, 2) :- b(2, 1) .", ParserContext::Rule),
             (
                 "%%% A directive \n   \t@declare a(_: int, _: int) .",
+                ParserContext::Directive,
+            ),
+            (
+                "#[external(?x)] \n @export test :- csv{resource = ?x}.",
                 ParserContext::Directive,
             ),
             (

--- a/nemo/src/parser/error.rs
+++ b/nemo/src/parser/error.rs
@@ -86,6 +86,7 @@ pub(crate) fn recover<'a>(
                     span: token.span(),
                     comment: None,
                     kind: StatementKind::Error(token),
+                    attributes: Default::default(),
                 },
             ))
         }

--- a/nemo/src/rule_model/components/rule.rs
+++ b/nemo/src/rule_model/components/rule.rs
@@ -17,8 +17,12 @@ use super::{
     atom::Atom,
     literal::Literal,
     term::{
-        operation::Operation,
-        primitive::{variable::Variable, Primitive},
+        operation::{operation_kind::OperationKind, Operation},
+        primitive::{
+            ground::GroundTerm,
+            variable::{universal::UniversalVariable, Variable},
+            Primitive,
+        },
         Term,
     },
     IterablePrimitives, IterableVariables, ProgramComponent, ProgramComponentKind,
@@ -576,6 +580,21 @@ impl RuleBuilder {
     /// Set the display property of the built rule.
     pub fn display_mut(&mut self, display: Term) -> &mut Self {
         self.display = Some(display);
+        self
+    }
+
+    pub fn add_external_variable(
+        &mut self,
+        variable: UniversalVariable,
+        expansion: GroundTerm,
+    ) -> &mut Self {
+        self.add_body_operation_mut(Operation::new(
+            OperationKind::Equal,
+            vec![
+                Term::Primitive(Primitive::Variable(Variable::Universal(variable))),
+                Term::Primitive(Primitive::Ground(expansion)),
+            ],
+        ));
         self
     }
 

--- a/nemo/src/rule_model/components/term/primitive/ground.rs
+++ b/nemo/src/rule_model/components/term/primitive/ground.rs
@@ -5,9 +5,13 @@ use std::{fmt::Display, hash::Hash};
 use nemo_physical::datavalues::{AnyDataValue, DataValue, IriDataValue, ValueDomain};
 
 use crate::rule_model::{
-    components::{term::value_type::ValueType, ProgramComponent, ProgramComponentKind},
-    error::ValidationErrorBuilder,
+    components::{
+        term::{value_type::ValueType, Term},
+        ProgramComponent, ProgramComponentKind,
+    },
+    error::{ComponentParseError, ValidationErrorBuilder},
     origin::Origin,
+    translation::TranslationComponent,
 };
 
 /// Primitive ground term
@@ -150,30 +154,19 @@ impl ProgramComponent for GroundTerm {
     }
 }
 
+impl GroundTerm {
+    pub fn parse(input: &str) -> Result<Self, ComponentParseError>
+    where
+        Self: Sized,
+    {
+        let term = Term::parse(input)?;
+        GroundTerm::try_from(term).map_err(|_| ComponentParseError::ParseError)
+    }
+}
+
 #[cfg(test)]
 mod test {
-    use crate::rule_model::{
-        components::term::{primitive::Primitive, Term},
-        error::ComponentParseError,
-        translation::TranslationComponent,
-    };
-
     use super::GroundTerm;
-
-    impl GroundTerm {
-        fn parse(input: &str) -> Result<Self, ComponentParseError>
-        where
-            Self: Sized,
-        {
-            let term = Term::parse(input)?;
-
-            if let Term::Primitive(Primitive::Ground(ground)) = term {
-                return Ok(ground);
-            }
-
-            Err(ComponentParseError::ParseError)
-        }
-    }
 
     #[test]
     fn parse_ground_term() {

--- a/nemo/src/rule_model/error/translation_error.rs
+++ b/nemo/src/rule_model/error/translation_error.rs
@@ -129,6 +129,14 @@ pub enum TranslationErrorKind {
     #[error("parameter {key} is defined multiple times")]
     #[assoc(code = 129)]
     MapParameterRedefined { key: String },
+    /// malformed external variable declaration
+    #[error("external variable must be a single universal variable")]
+    #[assoc(code = 130)]
+    ExternalVariableAttribute,
+    /// missing external variable
+    #[error("external variable was not supplied")]
+    #[assoc(code = 131)]
+    MissingExternalVariable,
 
     /// Unsupported: Declare statements
     #[error(r#"declare statements are currently unsupported"#)]

--- a/nemo/src/rule_model/error/translation_error.rs
+++ b/nemo/src/rule_model/error/translation_error.rs
@@ -134,7 +134,8 @@ pub enum TranslationErrorKind {
     #[assoc(code = 130)]
     ExternalVariableAttribute,
     /// missing external variable
-    #[error("external variable was not supplied")]
+    #[error("external variable is undefined")]
+    #[assoc(note = "consider using the `--param` cli option")]
     #[assoc(code = 131)]
     MissingExternalVariable,
 

--- a/nemo/src/rule_model/translation.rs
+++ b/nemo/src/rule_model/translation.rs
@@ -217,7 +217,7 @@ impl<'a, 'b> ASTProgramTranslation<'a, 'b> {
             ast::statement::StatementKind::Error(_) => &[],
         };
 
-        match process_attributes(self, statement.attributes().iter(), &expected_attributes) {
+        match process_attributes(self, statement.attributes().iter(), expected_attributes) {
             Ok(attributes) => self.statement_attributes = attributes,
             Err(error) => self.errors.push(ProgramError::TranslationError(error)),
         }

--- a/nemo/src/rule_model/translation.rs
+++ b/nemo/src/rule_model/translation.rs
@@ -305,7 +305,9 @@ impl<'a, 'b> ASTProgramTranslation<'a, 'b> {
                     }
                 }
                 ast::statement::StatementKind::Error(_token) => {
-                    todo!("Should faulty statements get ignored?")
+                    unreachable!(
+                        "Faulty statement should result in a parser error and not be propagated."
+                    )
                 }
             }
 

--- a/nemo/src/rule_model/translation/attribute.rs
+++ b/nemo/src/rule_model/translation/attribute.rs
@@ -29,18 +29,51 @@ use super::{ASTProgramTranslation, TranslationComponent};
 #[derive(Assoc, EnumIter, Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[func(pub fn name(&self) -> &'static str)]
 #[func(pub fn from_name(name: &str) -> Option<Self>)]
+#[func(pub fn unique(&self) -> bool)]
 #[func(pub fn schema(&self) -> Vec<(Option<ProgramComponentKind>, Option<ValueType>)>)]
 pub(crate) enum KnownAttributes {
     /// Name associated with a component
     #[assoc(name = "name")]
     #[assoc(from_name = "name")]
+    #[assoc(unique = true)]
     #[assoc(schema = vec![(Some(ProgramComponentKind::PlainString), None)])]
     Name,
     /// User-defined way of displaying the component
     #[assoc(name = "display")]
     #[assoc(from_name = "display")]
+    #[assoc(unique = true)]
     #[assoc(schema = vec![(None, Some(ValueType::String))])]
     Display,
+    /// Local variable, supplied by an external component (cli / APIs)
+    #[assoc(name = "external")]
+    #[assoc(from_name = "external")]
+    #[assoc(unique = false)]
+    #[assoc(schema = vec![(Some(ProgramComponentKind::Variable), None)])]
+    External,
+}
+
+#[derive(Debug)]
+pub(crate) struct Bag<K, V>(HashMap<K, Vec<V>>);
+
+impl<K, V> Default for Bag<K, V> {
+    fn default() -> Self {
+        Self(Default::default())
+    }
+}
+
+impl<V> Bag<KnownAttributes, V> {
+    pub(crate) fn get_unique(&self, attr: KnownAttributes) -> Option<&V> {
+        debug_assert!(attr.unique());
+        self.0.get(&attr).map(|v| &v[0])
+    }
+
+    pub(crate) fn get(&self, attr: KnownAttributes) -> &[V] {
+        self.0.get(&attr).map(|v| &**v).unwrap_or(&[])
+    }
+
+    pub(crate) fn clear(&mut self) {
+        self.0.clear();
+    }
 }
 
 /// Evaluates a list of attributes, checking for errors,
@@ -49,8 +82,8 @@ pub(crate) fn process_attributes<'a, 'b>(
     translation: &mut ASTProgramTranslation<'a, 'b>,
     attributes: impl Iterator<Item = &'b ast::attribute::Attribute<'a>>,
     expected: &[KnownAttributes],
-) -> Result<HashMap<KnownAttributes, Vec<Term>>, TranslationError> {
-    let mut result = HashMap::new();
+) -> Result<Bag<KnownAttributes, Vec<Term>>, TranslationError> {
+    let mut result = Bag(HashMap::new());
     let mut previous_attributes = HashMap::<KnownAttributes, Span<'a>>::new();
 
     for attribute in attributes {
@@ -74,16 +107,20 @@ pub(crate) fn process_attributes<'a, 'b>(
             ));
         }
 
-        if let Some(previous_span) = previous_attributes.get(&attribute_kind) {
-            let error =
-                TranslationError::new(attribute.span(), TranslationErrorKind::AttributeRedefined)
-                    .add_label(
-                        ComplexErrorLabelKind::Information,
-                        previous_span.range(),
-                        Info::FirstDefinition,
-                    );
+        if attribute_kind.unique() {
+            if let Some(previous_span) = previous_attributes.get(&attribute_kind) {
+                let error = TranslationError::new(
+                    attribute.span(),
+                    TranslationErrorKind::AttributeRedefined,
+                )
+                .add_label(
+                    ComplexErrorLabelKind::Information,
+                    previous_span.range(),
+                    Info::FirstDefinition,
+                );
 
-            return Err(error);
+                return Err(error);
+            }
         }
 
         let mut terms = Vec::<Term>::new();
@@ -134,7 +171,7 @@ pub(crate) fn process_attributes<'a, 'b>(
             terms.push(term);
         }
 
-        result.insert(attribute_kind, terms);
+        result.0.entry(attribute_kind).or_default().push(terms);
         previous_attributes.insert(attribute_kind, attribute.span());
     }
 

--- a/nemo/src/rule_model/translation/directive/import_export.rs
+++ b/nemo/src/rule_model/translation/directive/import_export.rs
@@ -79,7 +79,8 @@ fn import_export_spec<'a, 'b>(
         Substitution::default()
     };
 
-    for (variable, expansion) in translation.external_variables() {
+    for binding in translation.external_variables() {
+        let (variable, expansion) = binding?;
         substitution.insert(variable.clone(), expansion.clone());
     }
 

--- a/nemo/src/rule_model/translation/directive/import_export.rs
+++ b/nemo/src/rule_model/translation/directive/import_export.rs
@@ -73,11 +73,10 @@ fn import_export_spec<'a, 'b>(
 ) -> Result<ImportExportSpec, TranslationError> {
     let mut spec = Map::build_component(translation, instructions)?;
 
-    let mut substitution = if let Some(guards) = guards {
-        import_export_bindings(translation, guards.iter())?
-    } else {
-        Substitution::default()
-    };
+    let mut substitution = guards
+        .map(|guards| import_export_bindings(translation, guards.iter()))
+        .transpose()?
+        .unwrap_or_default();
 
     for binding in translation.external_variables() {
         let (variable, expansion) = binding?;

--- a/nemo/src/rule_model/translation/fact.rs
+++ b/nemo/src/rule_model/translation/fact.rs
@@ -5,6 +5,7 @@ use crate::{
     rule_model::{
         components::{fact::Fact, tag::Tag, term::Term},
         error::{translation_error::TranslationErrorKind, TranslationError},
+        substitution::Substitution,
     },
 };
 
@@ -17,13 +18,21 @@ impl TranslationComponent for Fact {
         translation: &mut super::ASTProgramTranslation<'a, 'b>,
         fact: &'b Self::Ast<'a>,
     ) -> Result<Self, TranslationError> {
+        let mut substitution = Substitution::default();
+
+        for (variable, expansion) in translation.external_variables() {
+            substitution.insert(variable.clone(), expansion.clone());
+        }
+
         let fact =
             if let ast::guard::Guard::Expression(ast::expression::Expression::Atom(atom)) = fact {
                 let predicate = Tag::from(translation.resolve_tag(atom.tag())?)
                     .set_origin(translation.register_node(atom.tag()));
                 let mut subterms = Vec::new();
                 for expression in atom.expressions() {
-                    subterms.push(Term::build_component(translation, expression)?);
+                    let mut term = Term::build_component(translation, expression)?;
+                    substitution.apply(&mut term);
+                    subterms.push(term);
                 }
 
                 translation.register_component(Fact::new(predicate, subterms), atom)

--- a/nemo/src/rule_model/translation/fact.rs
+++ b/nemo/src/rule_model/translation/fact.rs
@@ -20,7 +20,8 @@ impl TranslationComponent for Fact {
     ) -> Result<Self, TranslationError> {
         let mut substitution = Substitution::default();
 
-        for (variable, expansion) in translation.external_variables() {
+        for binding in translation.external_variables() {
+            let (variable, expansion) = binding?;
             substitution.insert(variable.clone(), expansion.clone());
         }
 

--- a/nemo/src/rule_model/translation/rule.rs
+++ b/nemo/src/rule_model/translation/rule.rs
@@ -49,7 +49,8 @@ impl TranslationComponent for Rule {
             rule_builder.display_mut(rule_display[0].clone());
         }
 
-        for (variable, expansion) in translation.external_variables() {
+        for binding in translation.external_variables() {
+            let (variable, expansion) = binding?;
             rule_builder.add_external_variable(variable.clone(), expansion.clone());
         }
 


### PR DESCRIPTION
You can now enjoy external variable support like in the following:

```prolog
#[external(?file)]
@import t :- csv { resource = ?file }.

#[external(?a)]
t(?a, 42).

@export t :- csv { resource = "" }.
```

Supply the parameters via cli:
```shell
nmo test_rules.rls --param 'file="test"' --param a=7
```

Note that you must properly escape double quotes, else they will be interpreted by the shell