### PR TITLE
Include rule attributes in json trace

### DIFF
--- a/nemo-python/src/lib.rs
+++ b/nemo-python/src/lib.rs
@@ -303,7 +303,7 @@ fn trace_to_dict<'py>(trace: &ExecutionTraceTree, py: Python<'py>) -> PyResult<B
             }
             if let Some(description) = rule_application
                 .rule
-                .description_instantiated(&rule_application.assignment)
+                .instantiated_display(&rule_application.assignment)
             {
                 result.set_item("description", description)?;
             }

--- a/nemo-python/src/lib.rs
+++ b/nemo-python/src/lib.rs
@@ -301,11 +301,11 @@ fn trace_to_dict<'py>(trace: &ExecutionTraceTree, py: Python<'py>) -> PyResult<B
             if let Some(name) = rule_application.rule.name() {
                 result.set_item("name", name)?;
             }
-            if let Some(description) = rule_application
+            if let Some(display) = rule_application
                 .rule
                 .instantiated_display(&rule_application.assignment)
             {
-                result.set_item("description", description)?;
+                result.set_item("display", display)?;
             }
 
             let subtraces: Vec<_> = subtraces

--- a/nemo-python/src/lib.rs
+++ b/nemo-python/src/lib.rs
@@ -298,6 +298,16 @@ fn trace_to_dict<'py>(trace: &ExecutionTraceTree, py: Python<'py>) -> PyResult<B
                 "assignment",
                 assignement_to_dict(&rule_application.assignment, py)?,
             )?;
+            if let Some(name) = rule_application.rule.name() {
+                result.set_item("name", name)?;
+            }
+            if let Some(description) = rule_application
+                .rule
+                .description_instantiated(&rule_application.assignment)
+            {
+                result.set_item("description", description)?;
+            }
+
             let subtraces: Vec<_> = subtraces
                 .iter()
                 .map(|trace| trace_to_dict(trace, py))

--- a/nemo-python/tests/test_example.py
+++ b/nemo-python/tests/test_example.py
@@ -29,6 +29,9 @@ class TestExample(unittest.TestCase):
         interesting(msg).
 
         interesting(?x) :- data(?x, ?y), interesting(?y).
+
+        #[name("interesting rule")]
+        #[name(f"data: {?x}, {?y}")]
         interesting(?y) :- data(?x, ?y), interesting(?x).
         """
 
@@ -89,6 +92,8 @@ class TestExample(unittest.TestCase):
         expected_trace = {
             "rule": "interesting(?y) :- data(?x, ?y), interesting(?x) .",
             "assignment": {"?x": 3.14, "?y": "<circle>"},
+            "name": "interesting rule",
+            "description": "data: 3.14, <circle>",
             "subtraces": [
                 {
                     "fact": 'data("3.14"^^<http://www.w3.org/2001/XMLSchema#double>, circle)'
@@ -96,6 +101,8 @@ class TestExample(unittest.TestCase):
                 {
                     "rule": "interesting(?y) :- data(?x, ?y), interesting(?x) .",
                     "assignment": {"?x": "<py>", "?y": 3.14},
+                    "name": "interesting rule",
+                    "description": "data: <py>, 3.14",
                     "subtraces": [
                         {
                             "fact": 'data(py, "3.14"^^<http://www.w3.org/2001/XMLSchema#double>)'

--- a/nemo-python/tests/test_example.py
+++ b/nemo-python/tests/test_example.py
@@ -31,7 +31,7 @@ class TestExample(unittest.TestCase):
         interesting(?x) :- data(?x, ?y), interesting(?y).
 
         #[name("interesting rule")]
-        #[name(f"data: {?x}, {?y}")]
+        #[display(f"data: {?x}, {?y}")]
         interesting(?y) :- data(?x, ?y), interesting(?x).
         """
 

--- a/nemo-python/tests/test_example.py
+++ b/nemo-python/tests/test_example.py
@@ -93,7 +93,7 @@ class TestExample(unittest.TestCase):
             "rule": "interesting(?y) :- data(?x, ?y), interesting(?x) .",
             "assignment": {"?x": 3.14, "?y": "<circle>"},
             "name": "interesting rule",
-            "description": "data: 3.14, circle",
+            "display": "data: 3.14, circle",
             "subtraces": [
                 {
                     "fact": 'data("3.14"^^<http://www.w3.org/2001/XMLSchema#double>, circle)'
@@ -102,7 +102,7 @@ class TestExample(unittest.TestCase):
                     "rule": "interesting(?y) :- data(?x, ?y), interesting(?x) .",
                     "assignment": {"?x": "<py>", "?y": 3.14},
                     "name": "interesting rule",
-                    "description": "data: py, 3.14",
+                    "display": "data: py, 3.14",
                     "subtraces": [
                         {
                             "fact": 'data(py, "3.14"^^<http://www.w3.org/2001/XMLSchema#double>)'

--- a/nemo-python/tests/test_example.py
+++ b/nemo-python/tests/test_example.py
@@ -93,7 +93,7 @@ class TestExample(unittest.TestCase):
             "rule": "interesting(?y) :- data(?x, ?y), interesting(?x) .",
             "assignment": {"?x": 3.14, "?y": "<circle>"},
             "name": "interesting rule",
-            "description": "data: 3.14, <circle>",
+            "description": "data: 3.14, circle",
             "subtraces": [
                 {
                     "fact": 'data("3.14"^^<http://www.w3.org/2001/XMLSchema#double>, circle)'
@@ -102,7 +102,7 @@ class TestExample(unittest.TestCase):
                     "rule": "interesting(?y) :- data(?x, ?y), interesting(?x) .",
                     "assignment": {"?x": "<py>", "?y": 3.14},
                     "name": "interesting rule",
-                    "description": "data: <py>, 3.14",
+                    "description": "data: py, 3.14",
                     "subtraces": [
                         {
                             "fact": 'data(py, "3.14"^^<http://www.w3.org/2001/XMLSchema#double>)'

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -223,7 +223,7 @@ impl TraceTreeRuleApplication {
 
     /// Get a string representation of the Instantiated rule.
     fn to_instantiated_string(&self) -> String {
-        if let Some(display_string) = self.rule.description_instantiated(&self.assignment) {
+        if let Some(display_string) = self.rule.instantiated_display(&self.assignment) {
             return display_string;
         }
 
@@ -407,7 +407,7 @@ impl From<ExecutionTraceInference> for ExecutionTraceInferenceJSON {
             rule_display: value
                 .trigger
                 .as_ref()
-                .and_then(|(rule, substitution)| rule.description_instantiated(substitution)),
+                .and_then(|(rule, substitution)| rule.instantiated_display(substitution)),
             conclusion: value.conclusion.to_string(),
             premises: value
                 .premises

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -223,7 +223,7 @@ impl TraceTreeRuleApplication {
 
     /// Get a string representation of the Instantiated rule.
     fn to_instantiated_string(&self) -> String {
-        if let Some(display_string) = self.rule.display_instantiated(&self.assignment) {
+        if let Some(display_string) = self.rule.description_instantiated(&self.assignment) {
             return display_string;
         }
 
@@ -407,7 +407,7 @@ impl From<ExecutionTraceInference> for ExecutionTraceInferenceJSON {
             rule_display: value
                 .trigger
                 .as_ref()
-                .and_then(|(rule, substitution)| rule.display_instantiated(substitution)),
+                .and_then(|(rule, substitution)| rule.description_instantiated(substitution)),
             conclusion: value.conclusion.to_string(),
             premises: value
                 .premises

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -382,10 +382,10 @@ struct ExecutionTraceInferenceJSON {
     #[serde(rename = "rule")]
     rule_string: String,
     /// Optionally provided name of the rule
-    #[serde(rename = "ruleName")]
+    #[serde(rename = "ruleName", skip_serializing_if = "Option::is_none")]
     rule_name: Option<String>,
     /// Optional human readable string representation of the rule
-    #[serde(rename = "ruleDisplay")]
+    #[serde(rename = "ruleDisplay", skip_serializing_if = "Option::is_none")]
     rule_display: Option<String>,
     /// Instantiated result of the rule application
     conclusion: String,
@@ -722,7 +722,7 @@ mod test {
         let trace_p_ba = trace.find_fact(&p_ba).unwrap();
         let trace_handles = vec![trace_r_ba, trace_p_ba];
 
-        let expected_json = r#"{"finalConclusion":["R(b, a)","P(b, a)"],"inferences":[{"ruleName":"R(?x, ?y) :- P(?x, ?y), S(?y) .","conclusion":"R(b, a)","premises":["P(b, a)","S(a)"]},{"ruleName":"S(?x) :- T(?x) .","conclusion":"S(a)","premises":["T(a)"]},{"ruleName":"Asserted","conclusion":"T(a)","premises":[]},{"ruleName":"P(?x, ?y) :- Q(?y, ?x) .","conclusion":"P(b, a)","premises":["Q(a, b)"]},{"ruleName":"Asserted","conclusion":"Q(a, b)","premises":[]}]}"#.to_string();
+        let expected_json = r#"{"finalConclusion":["R(b, a)","P(b, a)"],"inferences":[{"rule":"R(?x, ?y) :- P(?x, ?y), S(?y) .","conclusion":"R(b, a)","premises":["P(b, a)","S(a)"]},{"rule":"S(?x) :- T(?x) .","conclusion":"S(a)","premises":["T(a)"]},{"rule":"Asserted","conclusion":"T(a)","premises":[]},{"rule":"P(?x, ?y) :- Q(?y, ?x) .","conclusion":"P(b, a)","premises":["Q(a, b)"]},{"rule":"Asserted","conclusion":"Q(a, b)","premises":[]}]}"#.to_string();
         let computed_json = serde_json::to_string(&trace.json(&trace_handles)).unwrap();
 
         assert_eq!(expected_json, computed_json);

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -384,7 +384,7 @@ struct ExecutionTraceInferenceJSON {
     /// Optionally provided name of the rule
     #[serde(rename = "ruleName", skip_serializing_if = "Option::is_none")]
     rule_name: Option<String>,
-    /// Optional human readable string representation of the rule
+    /// Optional human readable string representation of a rule instance
     #[serde(rename = "ruleDisplay", skip_serializing_if = "Option::is_none")]
     rule_display: Option<String>,
     /// Instantiated result of the rule application

--- a/nemo/src/rule_model/components/rule.rs
+++ b/nemo/src/rule_model/components/rule.rs
@@ -40,8 +40,8 @@ pub struct Rule {
 
     /// Name of the rule
     name: Option<String>,
-    /// How an instantiated version of this rule should be displayed
-    display: Option<Term>,
+    /// Description of the rule
+    description: Option<Term>,
 
     /// Head of the rule
     head: Vec<Atom>,
@@ -60,7 +60,7 @@ impl Rule {
         Self {
             origin: Origin::Created,
             name: None,
-            display: None,
+            description: None,
             head,
             body,
         }
@@ -74,7 +74,7 @@ impl Rule {
 
     /// Set how an instantiated version of the rule should be displayed.
     pub fn set_display(mut self, display: Term) -> Self {
-        self.display = Some(display);
+        self.description = Some(display);
         self
     }
 
@@ -83,9 +83,11 @@ impl Rule {
         self.name.clone()
     }
 
-    /// Return a string representation of the rule instantiated with the given [Substitution].
-    pub fn display_instantiated(&self, substitution: &Substitution) -> Option<String> {
-        if let Some(mut display) = self.display.clone() {
+    /// Return a string representation of the rule's description with the given [Substitution].
+    ///
+    /// Returns `None` if `description` results not in a ground term after applying the substitution.
+    pub fn description_instantiated(&self, substitution: &Substitution) -> Option<String> {
+        if let Some(mut display) = self.description.clone() {
             substitution.apply(&mut display);
             if let Term::Primitive(Primitive::Ground(ground)) = display.reduce() {
                 return ground.value().to_plain_string();
@@ -368,7 +370,7 @@ impl ProgramComponent for Rule {
             .flat_map(|atom| atom.variables())
             .any(|variable| variable.is_existential());
 
-        if let Some(display) = &self.display {
+        if let Some(display) = &self.description {
             display.validate(builder)?;
 
             for variable in display.variables() {

--- a/nemo/src/rule_model/components/rule.rs
+++ b/nemo/src/rule_model/components/rule.rs
@@ -40,8 +40,9 @@ pub struct Rule {
 
     /// Name of the rule
     name: Option<String>,
-    /// Description of the rule
-    description: Option<Term>,
+    /// [Term] specifying how an instance of the rule should be displayed
+    /// in e.g. tracing
+    display: Option<Term>,
 
     /// Head of the rule
     head: Vec<Atom>,
@@ -60,7 +61,7 @@ impl Rule {
         Self {
             origin: Origin::Created,
             name: None,
-            description: None,
+            display: None,
             head,
             body,
         }
@@ -74,7 +75,7 @@ impl Rule {
 
     /// Set how an instantiated version of the rule should be displayed.
     pub fn set_display(mut self, display: Term) -> Self {
-        self.description = Some(display);
+        self.display = Some(display);
         self
     }
 
@@ -86,8 +87,8 @@ impl Rule {
     /// Return a string representation of the rule's description with the given [Substitution].
     ///
     /// Returns `None` if `description` results not in a ground term after applying the substitution.
-    pub fn description_instantiated(&self, substitution: &Substitution) -> Option<String> {
-        if let Some(mut display) = self.description.clone() {
+    pub fn instantiated_display(&self, substitution: &Substitution) -> Option<String> {
+        if let Some(mut display) = self.display.clone() {
             substitution.apply(&mut display);
             if let Term::Primitive(Primitive::Ground(ground)) = display.reduce() {
                 return ground.value().to_plain_string();
@@ -370,7 +371,7 @@ impl ProgramComponent for Rule {
             .flat_map(|atom| atom.variables())
             .any(|variable| variable.is_existential());
 
-        if let Some(display) = &self.description {
+        if let Some(display) = &self.display {
             display.validate(builder)?;
 
             for variable in display.variables() {

--- a/nemo/src/rule_model/components/rule.rs
+++ b/nemo/src/rule_model/components/rule.rs
@@ -78,30 +78,21 @@ impl Rule {
         self
     }
 
+    /// Return the name of the rule, if it is given one.
+    pub fn name(&self) -> Option<String> {
+        self.name.clone()
+    }
+
     /// Return a string representation of the rule instantiated with the given [Substitution].
-    /// This will either return
-    ///     * The content of the display attribute for this rule
-    ///     * a canonical string representation of the rule (i.e. [Display] representation)
-    /// whichever is the first defined in this list.
-    pub fn display_instantiated(&self, substitution: &Substitution) -> String {
+    pub fn display_instantiated(&self, substitution: &Substitution) -> Option<String> {
         if let Some(mut display) = self.display.clone() {
             substitution.apply(&mut display);
             if let Term::Primitive(Primitive::Ground(ground)) = display.reduce() {
-                if let Some(result) = ground.value().to_plain_string() {
-                    return result;
-                }
+                return ground.value().to_plain_string();
             }
         }
 
-        let mut rule_name_prefix = String::from("");
-        if let Some(name) = &self.name {
-            rule_name_prefix = format!("{}: ", name.clone());
-        }
-
-        let mut rule_instantiated = self.clone();
-        substitution.apply(&mut rule_instantiated);
-
-        format!("{}{}", rule_name_prefix, rule_instantiated)
+        None
     }
 
     /// Return a reference to the body of the rule.


### PR DESCRIPTION
This PR adds rule attributes (i.e. `#[name("rule name")]`, `#[display(f"result: {?x}")]`) into the json output format for tracing.

For example:
```
{
    "finalConclusion": [
        "ancestor(alice, gilbert)"
    ],
    "inferences": [
        {
            "conclusion": "ancestor(alice, gilbert)",
            "premises": [
                "ancestor(alice, edward)",
                "parent(edward, gilbert)"
            ],
            "rule": "ancestor(?X, ?Z) :- ancestor(?X, ?Y), parent(?Y, ?Z) .",
            "ruleDisplay": "alice, edward, gilbert -> alice, gilbert",
            "ruleName": "Ancestor Rule"
        },
     ...
    ]
}
```

Closes #627.