### PR TITLE
Bug/633 invalid format

### DIFF
--- a/nemo/src/rule_model/translation/complex/map.rs
+++ b/nemo/src/rule_model/translation/complex/map.rs
@@ -1,8 +1,6 @@
 //! This module contains a function to create a map term
 //! from the corresponding ast node.
 
-use log::debug;
-
 use crate::{
     parser::ast,
     rule_model::{

--- a/nemo/src/rule_model/translation/complex/map.rs
+++ b/nemo/src/rule_model/translation/complex/map.rs
@@ -1,10 +1,15 @@
 //! This module contains a function to create a map term
 //! from the corresponding ast node.
 
+use log::debug;
+
 use crate::{
     parser::ast,
     rule_model::{
-        components::term::{map::Map, Term},
+        components::{
+            tag::Tag,
+            term::{map::Map, Term},
+        },
         error::TranslationError,
         translation::{ASTProgramTranslation, TranslationComponent},
     },
@@ -26,7 +31,11 @@ impl TranslationComponent for Map {
         }
 
         let result = match map.tag() {
-            Some(tag) => Map::new(&translation.resolve_tag(tag)?, subterms),
+            Some(tag) => {
+                let tag = Tag::new(translation.resolve_tag(tag)?)
+                    .set_origin(translation.register_node(tag));
+                Map::new_tagged(Some(tag), subterms)
+            }
             None => Map::new_unnamed(subterms),
         };
 


### PR DESCRIPTION
This resolves #633 by registering a tag as external node. 
`Map::build_component()` is called from `import_export_spec()` and now will return a Tag with an external origin. 
I am not sure, if this change will have unwanted side effects since `Map::build_component()` is also called in `rule_model/translation/terms.rs`.

Another solution is to leave `map.rs` unchanged and correct the origin of the format tag in the `import_export_spec` function when creating a new `ImportExportSpec`:
```
old: 
    let mut result = ImportExportSpec::new(*spec.origin(), format_tag);
new:
    let format_tag = match instructions.tag() {
        Some(tag) => 
            format_tag.set_origin(translation.register_node(tag)),
        None => format_tag    
    }; 
    let mut result = ImportExportSpec::new(*spec.origin(), format_tag);
```
This solves the origin issue but the remaining `spec: Map` will still have an incorrect tag.