### PR TITLE
generalize substitution to also accept `Term`

### DIFF
--- a/nemo-python/src/lib.rs
+++ b/nemo-python/src/lib.rs
@@ -11,7 +11,12 @@ use nemo::{
     io::{resource_providers::ResourceProviders, ExportManager, ImportManager},
     meta::timing::TimedCode,
     rule_model::{
-        components::{fact::Fact, tag::Tag, term::primitive::Primitive, ProgramComponent},
+        components::{
+            fact::Fact,
+            tag::Tag,
+            term::{primitive::Primitive, Term},
+            ProgramComponent,
+        },
         error::ValidationErrorBuilder,
         substitution::Substitution,
     },
@@ -272,7 +277,7 @@ fn assignement_to_dict<'py>(
 ) -> PyResult<Bound<'py, PyDict>> {
     let dict = PyDict::new(py);
     for (variable, term) in assignment {
-        if let Primitive::Ground(ground) = term {
+        if let Term::Primitive(Primitive::Ground(ground)) = term {
             dict.set_item(
                 variable.to_string(),
                 datavalue_to_python(py, ground.value())?,

--- a/nemo/src/chase_model/components/atom/primitive_atom.rs
+++ b/nemo/src/chase_model/components/atom/primitive_atom.rs
@@ -94,6 +94,8 @@ impl IterableVariables for PrimitiveAtom {
 }
 
 impl IterablePrimitives for PrimitiveAtom {
+    type TermType = Primitive;
+
     fn primitive_terms<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Primitive> + 'a> {
         Box::new(self.terms.iter())
     }

--- a/nemo/src/chase_model/components/filter.rs
+++ b/nemo/src/chase_model/components/filter.rs
@@ -62,6 +62,8 @@ impl IterableVariables for ChaseFilter {
 }
 
 impl IterablePrimitives for ChaseFilter {
+    type TermType = Primitive;
+
     fn primitive_terms<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Primitive> + 'a> {
         self.filter.primitive_terms()
     }

--- a/nemo/src/chase_model/components/operation.rs
+++ b/nemo/src/chase_model/components/operation.rs
@@ -78,6 +78,8 @@ impl IterableVariables for ChaseOperation {
 }
 
 impl IterablePrimitives for ChaseOperation {
+    type TermType = Primitive;
+
     fn primitive_terms<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Primitive> + 'a> {
         self.operation.primitive_terms()
     }

--- a/nemo/src/chase_model/components/rule.rs
+++ b/nemo/src/chase_model/components/rule.rs
@@ -1,7 +1,10 @@
 //! This module defines [ChaseRule].
 
 use crate::rule_model::{
-    components::{term::primitive::variable::Variable, IterablePrimitives, IterableVariables},
+    components::{
+        term::primitive::{variable::Variable, Primitive},
+        IterablePrimitives, IterableVariables,
+    },
     origin::Origin,
 };
 
@@ -10,6 +13,7 @@ use super::{
     atom::{primitive_atom::PrimitiveAtom, variable_atom::VariableAtom},
     filter::ChaseFilter,
     operation::ChaseOperation,
+    term::operation_term::OperationTerm,
     ChaseComponent,
 };
 
@@ -328,10 +332,9 @@ impl IterableVariables for ChaseRule {
 }
 
 impl IterablePrimitives for ChaseRule {
-    fn primitive_terms<'a>(
-        &'a self,
-    ) -> Box<dyn Iterator<Item = &'a crate::rule_model::components::term::primitive::Primitive> + 'a>
-    {
+    type TermType = Primitive;
+
+    fn primitive_terms<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Primitive> + 'a> {
         let head_terms = self.head().iter().flat_map(|atom| atom.primitive_terms());
         let positive_operation_terms = self
             .positive_operations()
@@ -367,11 +370,7 @@ impl IterablePrimitives for ChaseRule {
         )
     }
 
-    fn primitive_terms_mut<'a>(
-        &'a mut self,
-    ) -> Box<
-        dyn Iterator<Item = &'a mut crate::rule_model::components::term::primitive::Primitive> + 'a,
-    > {
-        todo!()
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+        unimplemented!("currently unused, needs support in the entire chase model")
     }
 }

--- a/nemo/src/chase_model/components/rule.rs
+++ b/nemo/src/chase_model/components/rule.rs
@@ -13,7 +13,6 @@ use super::{
     atom::{primitive_atom::PrimitiveAtom, variable_atom::VariableAtom},
     filter::ChaseFilter,
     operation::ChaseOperation,
-    term::operation_term::OperationTerm,
     ChaseComponent,
 };
 

--- a/nemo/src/chase_model/components/term/operation_term.rs
+++ b/nemo/src/chase_model/components/term/operation_term.rs
@@ -79,6 +79,8 @@ impl IterableVariables for Operation {
 }
 
 impl IterablePrimitives for Operation {
+    type TermType = Primitive;
+
     fn primitive_terms<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Primitive> + 'a> {
         Box::new(self.subterms.iter().flat_map(|term| term.primitive_terms()))
     }
@@ -116,6 +118,8 @@ impl IterableVariables for OperationTerm {
 }
 
 impl IterablePrimitives for OperationTerm {
+    type TermType = Primitive;
+
     fn primitive_terms<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Primitive> + 'a> {
         match self {
             OperationTerm::Primitive(primitive) => Box::new(Some(primitive).into_iter()),

--- a/nemo/src/rule_model/components.rs
+++ b/nemo/src/rule_model/components.rs
@@ -16,7 +16,10 @@ pub mod term;
 use std::fmt::{Debug, Display};
 
 use enum_assoc::Assoc;
-use term::primitive::{variable::Variable, Primitive};
+use term::{
+    primitive::{variable::Variable, Primitive},
+    Term,
+};
 
 use super::{error::ValidationErrorBuilder, origin::Origin};
 
@@ -126,9 +129,13 @@ pub trait IterableVariables {
 
 /// Trait implemented by program components that allow iterating over [Primitive] terms
 pub trait IterablePrimitives {
+    type TermType = Term;
+
     /// Return an iterator over all [Primitive] terms contained within this program component.
     fn primitive_terms<'a>(&'a self) -> Box<dyn Iterator<Item = &'a Primitive> + 'a>;
 
     /// Return a mutable iterator over all [Primitive] terms contained within this program component.
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a>;
+    fn primitive_terms_mut<'a>(
+        &'a mut self,
+    ) -> Box<dyn Iterator<Item = &'a mut Self::TermType> + 'a>;
 }

--- a/nemo/src/rule_model/components/atom.rs
+++ b/nemo/src/rule_model/components/atom.rs
@@ -182,7 +182,7 @@ impl IterablePrimitives for Atom {
         Box::new(self.terms.iter().flat_map(|term| term.primitive_terms()))
     }
 
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Term> + 'a> {
         Box::new(
             self.terms
                 .iter_mut()

--- a/nemo/src/rule_model/components/fact.rs
+++ b/nemo/src/rule_model/components/fact.rs
@@ -174,7 +174,7 @@ impl IterablePrimitives for Fact {
         Box::new(self.subterms().flat_map(|term| term.primitive_terms()))
     }
 
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Term> + 'a> {
         Box::new(
             self.terms
                 .iter_mut()

--- a/nemo/src/rule_model/components/literal.rs
+++ b/nemo/src/rule_model/components/literal.rs
@@ -113,7 +113,7 @@ impl IterablePrimitives for Literal {
         }
     }
 
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Term> + 'a> {
         match self {
             Literal::Positive(literal) => literal.primitive_terms_mut(),
             Literal::Negative(literal) => literal.primitive_terms_mut(),

--- a/nemo/src/rule_model/components/rule.rs
+++ b/nemo/src/rule_model/components/rule.rs
@@ -539,7 +539,7 @@ impl IterablePrimitives for Rule {
         Box::new(head_primitives.chain(body_primitives))
     }
 
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Term> + 'a> {
         let head_primitives = self
             .head
             .iter_mut()

--- a/nemo/src/rule_model/components/term.rs
+++ b/nemo/src/rule_model/components/term.rs
@@ -427,9 +427,9 @@ impl IterablePrimitives for Term {
         }
     }
 
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Term> + 'a> {
         match self {
-            Term::Primitive(term) => Box::new(Some(term).into_iter()),
+            Term::Primitive(_) => Box::new(Some(self).into_iter()),
             Term::Aggregate(term) => term.primitive_terms_mut(),
             Term::FunctionTerm(term) => term.primitive_terms_mut(),
             Term::Map(term) => term.primitive_terms_mut(),

--- a/nemo/src/rule_model/components/term/aggregate.rs
+++ b/nemo/src/rule_model/components/term/aggregate.rs
@@ -315,7 +315,7 @@ impl IterablePrimitives for Aggregate {
         self.aggregate.primitive_terms()
     }
 
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Term> + 'a> {
         self.aggregate.primitive_terms_mut()
     }
 }

--- a/nemo/src/rule_model/components/term/function.rs
+++ b/nemo/src/rule_model/components/term/function.rs
@@ -214,7 +214,7 @@ impl IterablePrimitives for FunctionTerm {
         Box::new(self.terms.iter().flat_map(|term| term.primitive_terms()))
     }
 
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Term> + 'a> {
         Box::new(
             self.terms
                 .iter_mut()

--- a/nemo/src/rule_model/components/term/map.rs
+++ b/nemo/src/rule_model/components/term/map.rs
@@ -223,7 +223,7 @@ impl IterablePrimitives for Map {
         )
     }
 
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Term> + 'a> {
         Box::new(
             self.map.iter_mut().flat_map(|(key, value)| {
                 key.primitive_terms_mut().chain(value.primitive_terms_mut())

--- a/nemo/src/rule_model/components/term/operation.rs
+++ b/nemo/src/rule_model/components/term/operation.rs
@@ -302,7 +302,7 @@ impl IterablePrimitives for Operation {
         Box::new(self.subterms.iter().flat_map(|term| term.primitive_terms()))
     }
 
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Term> + 'a> {
         Box::new(
             self.subterms
                 .iter_mut()

--- a/nemo/src/rule_model/components/term/tuple.rs
+++ b/nemo/src/rule_model/components/term/tuple.rs
@@ -155,7 +155,7 @@ impl IterablePrimitives for Tuple {
         Box::new(self.terms.iter().flat_map(|term| term.primitive_terms()))
     }
 
-    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Primitive> + 'a> {
+    fn primitive_terms_mut<'a>(&'a mut self) -> Box<dyn Iterator<Item = &'a mut Term> + 'a> {
         Box::new(
             self.terms
                 .iter_mut()

--- a/nemo/src/rule_model/substitution.rs
+++ b/nemo/src/rule_model/substitution.rs
@@ -52,7 +52,7 @@ impl Substitution {
                 unreachable!()
             };
 
-            if let Some(replacement) = self.map.get(&primitive) {
+            if let Some(replacement) = self.map.get(primitive) {
                 *term = replacement.clone();
             }
         }


### PR DESCRIPTION
Note that Substitution::apply does not work for ChaseModel components anymore, as they have a more granular type structure. Implementing a separate case for them should not be to bad though in case it is needed at some point.