### PR TITLE
Feature/import stdin

### DIFF
--- a/nemo-physical/src/resource.rs
+++ b/nemo-physical/src/resource.rs
@@ -78,7 +78,7 @@ impl Resource {
     /// Whether the resource supports compression
     pub fn supports_compression(&self) -> bool {
         match self {
-            Resource::Pipe => false,       // never compress output to standard out
+            Resource::Pipe => false, // never compress input from standard in or output to standard out
             Resource::Http { .. } => true, // reqwest handles transport layer compression, but retrieved resources may still need decompression
             Resource::Path(_) => true,     // for local files, we need to handle compression
         }
@@ -175,7 +175,7 @@ impl fmt::Display for Resource {
                 }
             }
             Self::Path(path) => write!(f, "{}", path.display()),
-            Self::Pipe => f.write_str("stdin/stdout"),
+            Self::Pipe => f.write_str("standard in / standard out"),
         }
     }
 }
@@ -535,5 +535,19 @@ mod test {
         assert_eq!(resource.file_extension(), None);
 
         assert_eq!(Resource::Pipe.file_extension(), None);
+    }
+
+    #[test]
+    fn pipe() {
+        assert_eq!(
+            ResourceBuilder::try_from(String::from(""))
+                .expect("Valid shortcut for Pipe")
+                .finalize(),
+            Resource::Pipe
+        );
+        assert_eq!(
+            ResourceBuilder::default_resource_builder("", String::new()).finalize(),
+            Resource::Pipe
+        );
     }
 }

--- a/nemo-physical/src/resource.rs
+++ b/nemo-physical/src/resource.rs
@@ -94,7 +94,7 @@ impl Resource {
         matches!(self, Self::Path(..))
     }
 
-    /// Return if resource points to pipi
+    /// Return if resource points to pipe
     pub fn is_pipe(&self) -> bool {
         matches!(self, Self::Pipe)
     }

--- a/nemo-physical/src/resource.rs
+++ b/nemo-physical/src/resource.rs
@@ -70,15 +70,15 @@ pub enum Resource {
         /// Additional parameters sent with the HTTP request
         parameters: HttpParameters,
     },
-    /// Use stdout (only for export)
-    Stdout,
+    /// Use stdin for import, stdout for export
+    Pipe,
 }
 
 impl Resource {
     /// Whether the resource supports compression
     pub fn supports_compression(&self) -> bool {
         match self {
-            Resource::Stdout => false,     // never compress output to standard out
+            Resource::Pipe => false,       // never compress output to standard out
             Resource::Http { .. } => true, // reqwest handles transport layer compression, but retrieved resources may still need decompression
             Resource::Path(_) => true,     // for local files, we need to handle compression
         }
@@ -94,9 +94,9 @@ impl Resource {
         matches!(self, Self::Path(..))
     }
 
-    /// Return if resource points to stdout
-    pub fn is_stdout(&self) -> bool {
-        matches!(self, Self::Stdout)
+    /// Return if resource points to pipi
+    pub fn is_pipe(&self) -> bool {
+        matches!(self, Self::Pipe)
     }
 
     /// Return the headers
@@ -175,7 +175,7 @@ impl fmt::Display for Resource {
                 }
             }
             Self::Path(path) => write!(f, "{}", path.display()),
-            Self::Stdout => f.write_str("stdout"),
+            Self::Pipe => f.write_str("stdin/stdout"),
         }
     }
 }
@@ -281,15 +281,15 @@ impl ResourceBuilder {
         }
     }
 
-    /// Create a [ResourceBuilder] for [Resource::Stdout]
-    pub fn stdout_resource_builder() -> Self {
-        Self::try_from(String::from("")).expect("Empty string is valid resource for stdout")
+    /// Create a [ResourceBuilder] for [Resource::Pipe]
+    pub fn pipe_resource_builder() -> Self {
+        Self::try_from(String::from("")).expect("Empty string is valid resource for pipe")
     }
 
     /// Create a default [ResourceBuilder]
     pub fn default_resource_builder(predicate_name: &str, default_extension: String) -> Self {
         if predicate_name.is_empty() {
-            Self::stdout_resource_builder()
+            Self::pipe_resource_builder()
         } else {
             ResourceBuilder::try_from(format!("{predicate_name}.{}", default_extension))
                 .expect("default name is valid")
@@ -365,7 +365,7 @@ impl TryFrom<String> for ResourceBuilder {
             iri.try_into()
         } else if string.is_empty() {
             Ok(Self {
-                resource: Resource::Stdout,
+                resource: Resource::Pipe,
                 header_names: HashSet::new(),
             })
         } else {
@@ -534,6 +534,6 @@ mod test {
             .finalize();
         assert_eq!(resource.file_extension(), None);
 
-        assert_eq!(Resource::Stdout.file_extension(), None);
+        assert_eq!(Resource::Pipe.file_extension(), None);
     }
 }

--- a/nemo/src/chase_model/analysis/variable_order.rs
+++ b/nemo/src/chase_model/analysis/variable_order.rs
@@ -966,7 +966,7 @@ mod test {
     /// Helper function to create source-like imports
     fn csv_import(predicate: Tag, arity: usize) -> ChaseImport {
         let handler: Import = Import::new(
-            ResourceBuilder::stdout_resource_builder().finalize(),
+            ResourceBuilder::pipe_resource_builder().finalize(),
             Default::default(),
             arity,
             Arc::new(MockHandler),

--- a/nemo/src/io/export_manager.rs
+++ b/nemo/src/io/export_manager.rs
@@ -70,7 +70,7 @@ impl ExportManager {
     pub fn validate(&self, _predicate: &Tag, handler: &Export) -> Result<(), Error> {
         let resource = handler.resource();
 
-        if resource.is_stdout() {
+        if resource.is_pipe() {
             return Ok(());
         };
 
@@ -129,7 +129,7 @@ impl ExportManager {
     /// [ExportManager::disable_write] is `true`.
     fn writer(&self, export_handler: &Export, predicate: &Tag) -> Result<Box<dyn Write>, Error> {
         let resource = export_handler.resource();
-        let writer: Box<dyn Write> = if resource.is_stdout() {
+        let writer: Box<dyn Write> = if resource.is_pipe() {
             Box::new(std::io::stdout().lock())
         } else {
             let output_path = self.sanitized_path(resource, !export_handler.is_compressed())?;
@@ -177,7 +177,7 @@ impl ExportManager {
             table_writer.export_table_data(Box::new(table))?;
         }
 
-        Ok(export_handler.resource().is_stdout())
+        Ok(export_handler.resource().is_pipe())
     }
 
     /// Export a (possibly empty) table according to the given [ExportHandler],

--- a/nemo/src/io/format_builder.rs
+++ b/nemo/src/io/format_builder.rs
@@ -500,12 +500,7 @@ impl ImportExportBuilder {
                     })
                     .transpose()?;
 
-                let resource = rb.finalize();
-                if resource.is_stdout() && direction == Direction::Import {
-                    Err(ValidationErrorKind::UnsupportedStdoutImport)
-                } else {
-                    Ok(resource)
-                }
+                Ok(rb.finalize())
             })
             .transpose()
             .map_err(|err| builder.report_error(origin, err))

--- a/nemo/src/io/resource_providers.rs
+++ b/nemo/src/io/resource_providers.rs
@@ -12,6 +12,8 @@ use nemo_physical::{
 pub mod file;
 /// A resource provider for HTTP(s) requests.
 pub mod http;
+/// A resource provider for stdin.
+pub mod stdin;
 
 /// Allows resolving resources to readers.
 ///
@@ -54,6 +56,7 @@ impl ResourceProviders {
         Self(Rc::new(vec![
             Box::<http::HttpResourceProvider>::default(),
             Box::new(file::FileResourceProvider::new(base_path)),
+            Box::new(stdin::StdinResourceProvider::default()),
         ]))
     }
 

--- a/nemo/src/io/resource_providers/stdin.rs
+++ b/nemo/src/io/resource_providers/stdin.rs
@@ -1,0 +1,21 @@
+use super::ResourceProvider;
+use nemo_physical::{error::ReadingError, resource::Resource};
+use std::io::Read;
+
+#[derive(Debug, Clone, Copy, Default)]
+/// Resolves resources for Stdin
+pub struct StdinResourceProvider {}
+impl ResourceProvider for StdinResourceProvider {
+    fn open_resource(
+        &self,
+        resource: &Resource,
+        _media_type: &str,
+    ) -> Result<Option<Box<dyn Read>>, ReadingError> {
+        if !resource.is_pipe() {
+            return Ok(None);
+        }
+        let stdin = std::io::stdin();
+        let handle = stdin.lock();
+        Ok(Some(Box::new(handle)))
+    }
+}

--- a/nemo/src/rule_model/error/validation_error.rs
+++ b/nemo/src/rule_model/error/validation_error.rs
@@ -184,10 +184,10 @@ pub enum ValidationErrorKind {
         /// The actual [ValueDomain] of the HTTP parameter
         given: ValueDomain,
     },
-    /// Stdout is not supported for imports
-    #[error("resource `stdout` is not supported for imports")]
+    /// Stdin is only supported for one import
+    #[error("Expected at most one `stdin` import, found at least 2 occurrences")]
     #[assoc(code = 237)]
-    UnsupportedStdoutImport,
+    ReachedStdinImportLimit,
     /// Unsupported feature: Multiple aggregates in one rule
     #[error(r#"multiple aggregates in one rule is currently unsupported"#)]
     #[assoc(code = 999)]

--- a/nemo/src/rule_model/error/validation_error.rs
+++ b/nemo/src/rule_model/error/validation_error.rs
@@ -185,7 +185,7 @@ pub enum ValidationErrorKind {
         given: ValueDomain,
     },
     /// Stdin is only supported for one import
-    #[error("Expected at most one `stdin` import, found at least 2 occurrences")]
+    #[error("expected at most one `stdin` import, found at least 2 occurrences")]
     #[assoc(code = 237)]
     ReachedStdinImportLimit,
     /// Unsupported feature: Multiple aggregates in one rule

--- a/nemo/src/rule_model/program.rs
+++ b/nemo/src/rule_model/program.rs
@@ -243,10 +243,10 @@ impl Program {
         for (import_directive, import_builder) in self.imports() {
             let predicate = import_directive.predicate().clone();
             let origin = *import_directive.origin();
-            if matches!(
-                import_builder.resource().map(|resource| resource.is_pipe()),
-                Some(true)
-            ) {
+            if import_builder
+                .resource()
+                .is_some_and(|resource| resource.is_pipe())
+            {
                 count_stdin += 1;
                 if count_stdin > 1 {
                     builder.report_error(origin, ValidationErrorKind::ReachedStdinImportLimit);


### PR DESCRIPTION
This resolves #622 .
The error `ReachedStdinImportLimit` is caused if at least two import statements include `resource=""` e.g.,
```
@import foo :- csv{resource="",format=(int,int)}.
@import bar :- csv{resource="",format=(int,int)}.
```