### PR TITLE
Round negative floats and doubles towards 0.0

### DIFF
--- a/nemo-physical/src/datatypes/double.rs
+++ b/nemo-physical/src/datatypes/double.rs
@@ -79,9 +79,13 @@ impl Double {
     /// Returns the nearest integer to `self`.
     /// If a value is half-way between two integers, round away from 0.0.
     pub(crate) fn round(self) -> Self {
-        Double::new(self.0.round()).expect("operation returns valid float")
+        Double::new(if self.0.fract() == -0.5 {
+            self.0.ceil()
+        } else {
+            self.0.round()
+        })
+        .expect("operation returns valid float")
     }
-
     /// Returns the nearest integer to `self`.
     /// If a value is half-way between two integers, round away from 0.0.
     pub(crate) fn ceil(self) -> Self {

--- a/nemo-physical/src/datatypes/double.rs
+++ b/nemo-physical/src/datatypes/double.rs
@@ -77,7 +77,8 @@ impl Double {
     }
 
     /// Returns the nearest integer to `self`.
-    /// If a value is half-way between two integers, round away from 0.0.
+    /// If a value is half-way between two integers and positive, round away from 0.0.
+    /// If a value is half-way between two integers and negative, round towards 0.0.
     pub(crate) fn round(self) -> Self {
         Double::new(if self.0.fract() == -0.5 {
             self.0.ceil()

--- a/nemo-physical/src/datatypes/float.rs
+++ b/nemo-physical/src/datatypes/float.rs
@@ -77,9 +77,15 @@ impl Float {
     }
 
     /// Returns the nearest integer to `self`.
-    /// If a value is half-way between two integers, round away from 0.0.
+    /// If a value is half-way between two integers and positive, round away from 0.0.
+    /// If a value is half-way between two integers and negative, round towards 0.0.
     pub(crate) fn round(self) -> Self {
-        Float::new(self.0.round()).expect("operation returns valid float")
+        Float::new(if self.0.fract() == -0.5 {
+            self.0.ceil()
+        } else {
+            self.0.round()
+        })
+        .expect("operation returns valid float")
     }
 
     /// Returns the smallest integer greater than or equal to `self`.

--- a/nemo-physical/src/function/evaluation.rs
+++ b/nemo-physical/src/function/evaluation.rs
@@ -674,7 +674,7 @@ mod test {
         let tree_round = Function::numeric_round(Function::constant(any_float(-5.0)));
         evaluate_expect(&tree_round, Some(any_float(-5.0)));
         let tree_round = Function::numeric_round(Function::constant(any_float(-10.5)));
-        evaluate_expect(&tree_round, Some(any_float(-11.0)));
+        evaluate_expect(&tree_round, Some(any_float(-10.0)));
         let tree_round = Function::numeric_round(Function::constant(any_float(-10.2)));
         evaluate_expect(&tree_round, Some(any_float(-10.0)));
         let tree_round = Function::numeric_round(Function::constant(any_float(-10.8)));
@@ -820,7 +820,7 @@ mod test {
         let tree_round = Function::numeric_round(Function::constant(any_double(-5.0)));
         evaluate_expect(&tree_round, Some(any_double(-5.0)));
         let tree_round = Function::numeric_round(Function::constant(any_double(-10.5)));
-        evaluate_expect(&tree_round, Some(any_double(-11.0)));
+        evaluate_expect(&tree_round, Some(any_double(-10.0)));
         let tree_round = Function::numeric_round(Function::constant(any_double(-10.2)));
         evaluate_expect(&tree_round, Some(any_double(-10.0)));
         let tree_round = Function::numeric_round(Function::constant(any_double(-10.8)));


### PR DESCRIPTION
This resolves #634 by adding a special case that checks if the fractional part of a float or double equals `-0.5`. If this occurs `ceil()` is used instead of `round()`.