### PR TITLE
Display error if ground operation is invalid

### DIFF
--- a/nemo/src/chase_model/translation/fact.rs
+++ b/nemo/src/chase_model/translation/fact.rs
@@ -31,7 +31,7 @@ impl ProgramChaseTranslation {
             if let Term::Primitive(Primitive::Ground(value)) = reduced {
                 terms.push(value.clone());
             } else {
-                unreachable!("invalid program: fact contains non-primitive values")
+                panic!("invalid program: fact contains non-primitive values")
             }
         }
 

--- a/nemo/src/rule_model/components/term/operation.rs
+++ b/nemo/src/rule_model/components/term/operation.rs
@@ -368,7 +368,7 @@ mod test {
             let mut builder = ValidationErrorBuilder::default();
             let result = operation.validate(&mut builder);
             assert!(result.is_none());
-            assert_eq!(builder.finalize().is_empty(), false);
+            assert!(!builder.finalize().is_empty());
         }
     }
 }

--- a/nemo/src/rule_model/components/term/operation.rs
+++ b/nemo/src/rule_model/components/term/operation.rs
@@ -271,7 +271,7 @@ impl ProgramComponent for Operation {
             return None;
         }
 
-        if self.is_ground() && matches!(self.reduce(), Term::Operation(_)) {
+        if self.is_ground() && !self.reduce().is_primitive() {
             builder.report_error(self.origin, ValidationErrorKind::InvalidGroundOperation);
             return None;
         }

--- a/nemo/src/rule_model/error/validation_error.rs
+++ b/nemo/src/rule_model/error/validation_error.rs
@@ -189,7 +189,7 @@ pub enum ValidationErrorKind {
     #[assoc(code = 237)]
     ReachedStdinImportLimit,
     /// Ground operation contains invalid literals
-    #[error("ground operation contains at least one invalid literal")]
+    #[error("ground operation does not return a result")]
     #[assoc(code = 238)]
     InvalidGroundOperation,
     /// Unsupported feature: Multiple aggregates in one rule

--- a/nemo/src/rule_model/error/validation_error.rs
+++ b/nemo/src/rule_model/error/validation_error.rs
@@ -188,6 +188,10 @@ pub enum ValidationErrorKind {
     #[error("expected at most one `stdin` import, found at least 2 occurrences")]
     #[assoc(code = 237)]
     ReachedStdinImportLimit,
+    /// Ground operation contains invalid literals
+    #[error("ground operation contains at least one invalid literal")]
+    #[assoc(code = 238)]
+    InvalidGroundOperation,
     /// Unsupported feature: Multiple aggregates in one rule
     #[error(r#"multiple aggregates in one rule is currently unsupported"#)]
     #[assoc(code = 999)]


### PR DESCRIPTION
Verify the result of ground operations during validation process to display a `ValidationErrorKind::InvalidGroundOperation` error message.
Resolves #658.