### PR TITLE
Feature/635 empty string as result of the LANG function

### DIFF
--- a/nemo-physical/src/function/definitions/language.rs
+++ b/nemo-physical/src/function/definitions/language.rs
@@ -10,8 +10,8 @@ use super::{FunctionTypePropagation, UnaryFunction};
 /// Language tag
 ///
 /// Returns the language tag as a string of a language tagged string.
-/// Returns the empty string if parameter is a string
-/// Returns `None` if parameter is neither string nor language tagged string.
+/// Returns the empty string if value is a string.
+/// Returns `None` if value is neither string nor language tagged string.
 #[derive(Debug, Copy, Clone)]
 pub struct LanguageTag;
 impl UnaryFunction for LanguageTag {
@@ -47,8 +47,8 @@ mod test {
         let lang_tag =
             AnyDataValue::new_language_tagged_string("Roberto".to_string(), "en".to_string());
         let exp_result = AnyDataValue::new_plain_string("en".to_string());
-        let result = LanguageTag.evaluate(lang_tag);
-        assert_eq!(result.unwrap(), exp_result);
+        let result = LanguageTag.evaluate(lang_tag).unwrap();
+        assert_eq!(result, exp_result);
 
         let string = AnyDataValue::new_plain_string("Roberto".to_string());
         let empty_result = AnyDataValue::new_plain_string("".to_string());


### PR DESCRIPTION
Resolves #635 by returning the empty string when using the `LANG` function on a string that has no language tag.