### PR TITLE
Bring down miri runtime

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -75,7 +75,7 @@ jobs:
           components: miri
           rust-version: nightly
       - run: cargo miri setup
-      - run: cargo miri test
+      - run: cargo miri test -- -Z unstable-options --report-time
 
   test-python:
     name: Test python bindings

--- a/nemo-physical/Cargo.toml
+++ b/nemo-physical/Cargo.toml
@@ -10,12 +10,13 @@ readme = "README.md"
 repository.workspace = true
 
 [features]
-stringpairdictionary = []
 check_column_sorting = []
+old_dictionaries = []
 
 [[bin]]
 name = "dict-bench"
 path = "src/benches/dict-bench.rs"
+required-features = ["old_dictionaries"]
 
 [dependencies]
 enum_dispatch = "0.3.12"

--- a/nemo-physical/src/dictionary.rs
+++ b/nemo-physical/src/dictionary.rs
@@ -34,4 +34,5 @@ pub(crate) mod tuple_dv_dict;
 
 pub mod meta_dv_dict;
 
+#[cfg(feature = "old_dictionaries")]
 pub mod old_dictionaries;

--- a/nemo/src/execution/tracing/trace.rs
+++ b/nemo/src/execution/tracing/trace.rs
@@ -692,6 +692,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn trace_ascii() {
         let trace = test_trace();
         let r_ba = GroundAtom::try_from(Atom::parse("R(b,a)").unwrap()).unwrap();
@@ -712,6 +713,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn trace_json() {
         let trace = test_trace();
 

--- a/nemo/src/io/formats/sparql.rs
+++ b/nemo/src/io/formats/sparql.rs
@@ -235,6 +235,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_import() {
         let parser_input = ParserInput::new(
             r#"@import response :- sparql {endpoint = "http://example.org", query="SELECT ?a ?b ?c WHERE {?a ?b ?c.}", iri_fragment="section1", http_get_parameters={test=foo}, http_post_parameters={test=(foo,bar)}, http_headers={ACCEPT="html/text"}}"#,

--- a/nemo/src/parser/ast/directive.rs
+++ b/nemo/src/parser/ast/directive.rs
@@ -171,6 +171,7 @@ mod test {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_directive() {
         let test = vec![
             ("@base <test>", ParserContext::Base),

--- a/nemo/src/parser/ast/expression.rs
+++ b/nemo/src/parser/ast/expression.rs
@@ -192,6 +192,7 @@ mod test {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_expression() {
         let test = vec![
             ("#sum(1 + POW(?x, 2), ?y, ?z)", ParserContext::Aggregation),

--- a/nemo/src/parser/ast/expression/complex/arithmetic.rs
+++ b/nemo/src/parser/ast/expression/complex/arithmetic.rs
@@ -303,6 +303,7 @@ mod test {
     }
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_arithmetic() {
         let test = vec![
             ("1 * 2", 2),

--- a/nemo/src/parser/ast/expression/complex/map.rs
+++ b/nemo/src/parser/ast/expression/complex/map.rs
@@ -112,6 +112,7 @@ mod test {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_map() {
         let test = vec![
             ("{?x=7}", (None, 1)),

--- a/nemo/src/parser/ast/expression/complex/tuple.rs
+++ b/nemo/src/parser/ast/expression/complex/tuple.rs
@@ -89,6 +89,7 @@ mod test {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_tuple() {
         let test = vec![
             ("(1,)", 1),

--- a/nemo/src/parser/ast/guard.rs
+++ b/nemo/src/parser/ast/guard.rs
@@ -75,6 +75,7 @@ mod test {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_guard() {
         let test = vec![
             ("test(?x, (1,), (1 + 2))", ParserContext::Atom),

--- a/nemo/src/parser/ast/program.rs
+++ b/nemo/src/parser/ast/program.rs
@@ -125,6 +125,7 @@ mod test {
     use crate::parser::{ast::ProgramAST, input::ParserInput, ParserState, Program};
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_program() {
         let program = "%! Top-level comment\n\
             % Declarations:\n\
@@ -151,8 +152,8 @@ mod test {
         assert_eq!(result.1.statements.len(), 4);
     }
 
-    // TODO: This test cases causes a warning in miri
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parser_recover() {
         let program = "%! Top-level comment\n\
             % Declarations:\n\

--- a/nemo/src/parser/ast/rule.rs
+++ b/nemo/src/parser/ast/rule.rs
@@ -96,6 +96,7 @@ mod test {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_rule() {
         let test = vec![
             ("a(?x, ?y) :- b(?x, ?y)", (1, 1)),

--- a/nemo/src/parser/ast/sequence/key_value.rs
+++ b/nemo/src/parser/ast/sequence/key_value.rs
@@ -79,6 +79,7 @@ mod test {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_expression_sequence_simple() {
         let test = vec![
             ("", 0),

--- a/nemo/src/parser/ast/statement.rs
+++ b/nemo/src/parser/ast/statement.rs
@@ -161,6 +161,7 @@ mod test {
     };
 
     #[test]
+    #[cfg_attr(miri, ignore)]
     fn parse_statement() {
         let test = vec![
             (


### PR DESCRIPTION
Ignore some very time-consuming tests for `miri` to bring CI times towards a more acceptable level. Also disables building of the old dictionary code by default.