### PR TITLE
Add logs for tracing progress

### DIFF
--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -215,6 +215,7 @@ fn handle_tracing(
 ) -> Result<(), CliError> {
     let tracing_facts = parse_trace_facts(cli)?;
     if !tracing_facts.is_empty() {
+        log::info!("Starting tracing of {} facts...", tracing_facts.len());
         let mut facts = Vec::<Fact>::with_capacity(tracing_facts.len());
         for fact_string in &tracing_facts {
             let fact = Fact::parse(fact_string).map_err(|_| CliError::TracingInvalidFact {

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -490,9 +490,20 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
         let mut trace = ExecutionTrace::new(program);
         let mut handles = Vec::new();
 
-        for chase_fact in chase_facts {
+        let num_chase_facts = chase_facts.len();
+
+        for (i, chase_fact) in chase_facts.into_iter().enumerate() {
+            if i > 0 && i % 500 == 0 {
+                log::info!(
+                    "{i}/{num_chase_facts} facts traced. ({}%)",
+                    i * 100 / num_chase_facts
+                );
+            }
+
             handles.push(self.trace_recursive(&mut trace, chase_fact)?);
         }
+
+        log::info!("{num_chase_facts}/{num_chase_facts} facts traced. (100%)");
 
         Ok((trace, handles))
     }


### PR DESCRIPTION
Addresses #676.
We now log the tracing progress every 500 facts when the log level is at least `info`.