### PR TITLE
Rename count_rows/facts functions to ..._in_memory

### DIFF
--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -382,7 +382,7 @@ fn run(mut cli: CliApp) -> Result<(), CliError> {
 
     if print_summary {
         print_finished_message(
-            engine.count_facts_of_derived_predicates(),
+            engine.count_facts_in_memory_for_derived_predicates(),
             !export_manager.write_disabled(),
         );
     }

--- a/nemo-physical/src/management/database.rs
+++ b/nemo-physical/src/management/database.rs
@@ -127,11 +127,9 @@ impl DatabaseInstance {
         self.reference_manager.table_size_bytes(id)
     }
 
-    /// Return the number of rows contained in this table.
-    ///
-    /// TODO: Currently only counting of in-memory facts is supported, see <https://github.com/knowsys/nemo/issues/335>
-    pub fn count_rows(&self, id: PermanentTableId) -> usize {
-        self.reference_manager.count_rows(id)
+    /// Return the number of in-memory rows contained in this table.
+    pub fn count_rows_in_memory(&self, id: PermanentTableId) -> usize {
+        self.reference_manager.count_rows_in_memory(id)
     }
 
     /// Provide an iterator over the rows of the table with the given [PermanentTableId].

--- a/nemo-physical/src/management/database/order.rs
+++ b/nemo-physical/src/management/database/order.rs
@@ -97,15 +97,13 @@ impl OrderedReferenceManager {
         }
     }
 
-    /// Return the number of rows contained in this table.
-    ///
-    /// TODO: Currently only counting of in-memory facts is supported, see <https://github.com/knowsys/nemo/issues/335>
-    pub(crate) fn count_rows(&self, id: PermanentTableId) -> usize {
+    /// Return the number of in-memory rows contained in this table.
+    pub(crate) fn count_rows_in_memory(&self, id: PermanentTableId) -> usize {
         let (id, _) = self.resolve_reference(id, ColumnOrder::default());
 
         if let Some(order_map) = self.storage_map.get(&id) {
             if let Some(&storage_id) = order_map.values().next() {
-                return self.stored_tables[storage_id].count_rows();
+                return self.stored_tables[storage_id].count_rows_in_memory();
             }
 
             unreachable!("At least one entry must exist");

--- a/nemo-physical/src/management/database/storage.rs
+++ b/nemo-physical/src/management/database/storage.rs
@@ -96,11 +96,10 @@ impl TableStorage {
         }
     }
 
-    /// Return the number of rows that are stored in this table.
-    pub(crate) fn count_rows(&self) -> usize {
+    /// Return the number of rows that are stored in memory for this table.
+    pub(crate) fn count_rows_in_memory(&self) -> usize {
         match self {
             TableStorage::InMemory(trie) => trie.num_rows(),
-            // TODO: Currently only counting of in-memory facts is supported, see <https://github.com/knowsys/nemo/issues/335>
             TableStorage::FromSources(_) => 0,
             TableStorage::Empty => 0,
         }

--- a/nemo-wasm/src/lib.rs
+++ b/nemo-wasm/src/lib.rs
@@ -309,14 +309,15 @@ impl NemoEngine {
             .map_err(NemoError)
     }
 
-    #[wasm_bindgen(js_name = "countFactsOfDerivedPredicates")]
-    pub fn count_facts_of_derived_predicates(&mut self) -> usize {
-        self.engine.count_facts_of_derived_predicates()
+    #[wasm_bindgen(js_name = "countFactsInMemoryForDerivedPredicates")]
+    pub fn count_facts_in_memory_for_derived_predicates(&mut self) -> usize {
+        self.engine.count_facts_in_memory_for_derived_predicates()
     }
 
-    #[wasm_bindgen(js_name = "countFactsOfPredicate")]
-    pub fn count_facts_of_predicate(&mut self, predicate: String) -> Option<usize> {
-        self.engine.count_facts_of_predicate(&predicate.into())
+    #[wasm_bindgen(js_name = "countFactsInMemoryForPredicate")]
+    pub fn count_facts_in_memory_for_predicate(&mut self, predicate: String) -> Option<usize> {
+        self.engine
+            .count_facts_in_memory_for_predicate(&predicate.into())
     }
 
     #[wasm_bindgen(js_name = "getResult")]

--- a/nemo/src/execution/execution_engine.rs
+++ b/nemo/src/execution/execution_engine.rs
@@ -288,26 +288,19 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
             .collect()
     }
 
-    /// Counts the facts of a single predicate.
-    ///
-    /// TODO: Currently only counting of in-memory facts is supported, see <https://github.com/knowsys/nemo/issues/335>
-    pub fn count_facts_of_predicate(&self, predicate: &Tag) -> Option<usize> {
-        self.table_manager.predicate_count_rows(predicate)
+    /// Counts the facts of a single predicate that are currently in memory.
+    pub fn count_facts_in_memory_for_predicate(&self, predicate: &Tag) -> Option<usize> {
+        self.table_manager
+            .count_rows_in_memory_for_predicate(predicate)
     }
 
-    /// Count the number of facts of derived predicates.
-    ///
-    /// TODO: Currently only counting of in-memory facts is supported, see <https://github.com/knowsys/nemo/issues/335>
-    pub fn count_facts_of_derived_predicates(&self) -> usize {
-        let mut result = 0;
-
-        for predicate in &self.analysis.derived_predicates {
-            if let Some(count) = self.count_facts_of_predicate(predicate) {
-                result += count;
-            }
-        }
-
-        result
+    /// Count the number of facts of derived predicates that are currently in memory.
+    pub fn count_facts_in_memory_for_derived_predicates(&self) -> usize {
+        self.analysis
+            .derived_predicates
+            .iter()
+            .map(|p| self.count_facts_in_memory_for_predicate(p).unwrap_or(0))
+            .sum()
     }
 
     /// Return the amount of consumed memory for the tables used by the chase.

--- a/nemo/src/table_manager.rs
+++ b/nemo/src/table_manager.rs
@@ -117,15 +117,11 @@ impl SubtableHandler {
         Some(self.single[postion].1)
     }
 
-    /// TODO: Currently only counting of in-memory facts is supported, see <https://github.com/knowsys/nemo/issues/335>
-    pub fn count_rows(&self, database: &DatabaseInstance) -> usize {
-        let mut result = 0;
-
-        for (_, subtable_id) in &self.single {
-            result += database.count_rows(*subtable_id);
-        }
-
-        result
+    pub fn count_rows_in_memory(&self, database: &DatabaseInstance) -> usize {
+        self.single
+            .iter()
+            .map(|(_, subtable_id)| database.count_rows_in_memory(*subtable_id))
+            .sum()
     }
 
     pub fn add_single_table(&mut self, step: usize, id: PermanentTableId) {
@@ -363,13 +359,11 @@ impl TableManager {
         self.predicate_subtables.get(predicate)?.last_step()
     }
 
-    /// Count all the rows in the table manager that belong to a predicate.
-    ///
-    /// TODO: Currently only counting of in-memory facts is supported, see <https://github.com/knowsys/nemo/issues/335>
-    pub(crate) fn predicate_count_rows(&self, predicate: &Tag) -> Option<usize> {
+    /// Count all in-memory rows in the table manager that belong to a predicate.
+    pub(crate) fn count_rows_in_memory_for_predicate(&self, predicate: &Tag) -> Option<usize> {
         self.predicate_subtables
             .get(predicate)
-            .map(|s| s.count_rows(&self.database))
+            .map(|s| s.count_rows_in_memory(&self.database))
     }
 
     /// Get a list of column iterators for the full table (i.e. the expanded trie)


### PR DESCRIPTION
Closes #335 
Functions related to counting facts or rows in tables have been renamed to reflect that only facts/rows in memory are considered. That is, counts for tables that have not been loaded from the disk or from another resource are always zero.