### PR TITLE
Fix import of compressed RDF files via HTTP

### DIFF
--- a/nemo/src/io/compression_format.rs
+++ b/nemo/src/io/compression_format.rs
@@ -8,7 +8,10 @@ use std::{
 use flate2::Compression;
 
 use gzip::Gzip;
-use nemo_physical::{error::ReadingError, resource::ResourceBuilder};
+use nemo_physical::{
+    error::ReadingError,
+    resource::{Resource, ResourceBuilder},
+};
 
 use crate::syntax::import_export::{attribute, file_format};
 
@@ -54,7 +57,21 @@ impl Display for CompressionFormat {
 const GZIP_COMPRESSION_LEVEL: Compression = Compression::new(6);
 
 impl CompressionFormat {
-    /// Derive a compression format from the file extension of the given resource builder.
+    fn from_file_extension(file_extension: Option<&str>) -> Self {
+        match file_extension {
+            Some(file_format::EXTENSION_GZ) => Self::GZip,
+            _ => Self::None,
+        }
+    }
+
+    /// Derive a compression format from the file extension of the
+    /// given resource.
+    pub fn from_resource(resource: &Resource) -> Self {
+        Self::from_file_extension(resource.file_extension().as_deref())
+    }
+
+    /// Derive a compression format from the file extension of the
+    /// given resource builder.
     pub fn from_resource_builder(builder: &Option<ResourceBuilder>) -> Self {
         let Some(builder) = builder else {
             return Self::None;
@@ -64,10 +81,13 @@ impl CompressionFormat {
             return Self::None;
         }
 
-        match builder.file_extension() {
-            Some(file_format::EXTENSION_GZ) => Self::GZip,
-            _ => Self::None,
-        }
+        Self::from_file_extension(builder.file_extension().as_deref())
+    }
+
+    /// Return the file extension of the uncompressed file obtained
+    /// from the given resource.
+    pub fn uncompressed_file_extension(&self, resource: &Resource) -> Option<String> {
+        resource.file_extension_uncompressed(self.extension())
     }
 }
 

--- a/nemo/src/io/formats/rdf.rs
+++ b/nemo/src/io/formats/rdf.rs
@@ -27,9 +27,12 @@ use writer::RdfWriter;
 
 use crate::{
     error::Error,
-    io::format_builder::{
-        format_parameter, format_tag, value_type_matches, AnyImportExportBuilder, FormatParameter,
-        Parameters, StandardParameter,
+    io::{
+        compression_format::CompressionFormat,
+        format_builder::{
+            format_parameter, format_tag, value_type_matches, AnyImportExportBuilder,
+            FormatParameter, Parameters, StandardParameter,
+        },
     },
     rule_model::{
         components::{import_export::Direction, term::value_type::ValueType},
@@ -209,8 +212,10 @@ impl FormatBuilder for RdfHandler {
                     .get_required(RdfParameter::BaseParamType(StandardParameter::Resource));
 
                 let resource = ResourceBuilder::try_from(value)?.finalize();
+                let compression_format = CompressionFormat::from_resource(&resource);
 
-                let Some(extension) = resource.file_extension() else {
+                let Some(extension) = compression_format.uncompressed_file_extension(&resource)
+                else {
                     return Err(ValidationErrorKind::RdfUnspecifiedMissingExtension);
                 };
 
@@ -218,7 +223,7 @@ impl FormatBuilder for RdfHandler {
                     .iter()
                     .find(|variant| extension == variant.default_extension())
                 else {
-                    return Err(ValidationErrorKind::RdfUnspecifiedUnknownExtension(
+                    return Err(ValidationErrorKind::RdfUnknownExtension(
                         extension.to_string(),
                     ));
                 };

--- a/nemo/src/rule_model/error/validation_error.rs
+++ b/nemo/src/rule_model/error/validation_error.rs
@@ -146,14 +146,18 @@ pub enum ValidationErrorKind {
     FactSubtermAggregate,
     /// RDF unspecified missing extension
     #[error("no file extension specified")]
-    #[assoc(note = "rdf imports/exports must have file extension nt, nq, ttl, trig, or rdf.")]
+    #[assoc(
+        note = "RDF imports/exports must have file extension `nt`, `nq`, `ttl`, `trig`, or `rdf`."
+    )]
     #[assoc(code = 229)]
     RdfUnspecifiedMissingExtension,
-    /// RDF unspecified missing extension
-    #[error("`{0}` is not an rdf format")]
-    #[assoc(note = "rdf imports/exports must have file extension nt, nq, ttl, trig, or rdf.")]
+    /// RDF unknown extension
+    #[error("`{0}` is not an RDF format")]
+    #[assoc(
+        note = "RDF imports/exports must have file extension `nt`, `nq`, `ttl`, `trig`, or `rdf`."
+    )]
     #[assoc(code = 230)]
-    RdfUnspecifiedUnknownExtension(String),
+    RdfUnknownExtension(String),
     /// Unknown file format
     #[error(r#"unknown file format: `{0}`"#)]
     #[assoc(code = 231)]


### PR DESCRIPTION
Fixes HTTP imports of compressed RDF files, as in the following program, by correctly stripping the `.gz` before checking for a known RDF format:

```
@import TRIPLE :- rdf{resource="https://raw.githubusercontent.com/knowsys/nemo-examples/main/examples/owl-el/from-owl-rdf/galen-el.nt.gz"} .
```