### PR TITLE
Build docker image with nix and push to ghcr

### DIFF
--- a/.github/workflows/nix-and-docker.yml
+++ b/.github/workflows/nix-and-docker.yml
@@ -1,4 +1,4 @@
-name: Build with nix
+name: Build with nix and create docker image
 
 on:
   push:
@@ -7,11 +7,13 @@ on:
 
 env:
   RUST_BACKTRACE: 1
+  REGISTRY: ghcr.io
 
 jobs:
   evaluate:
-    name: Make sure that the nix flake evaluates and run the checks
+    name: Make sure that the nix flake evaluates and run the checks; then build docker image from flake and push it to registry.
     runs-on: ubuntu-latest
+
     steps:
       - uses: actions/checkout@v4
       - uses: cachix/install-nix-action@v31
@@ -31,8 +33,22 @@ jobs:
           purge-last-accessed: 0
           purge-primary-key: never
       - run: nix flake check
-      - name: Collect garbage
+      - name: Build and Collect garbage
         run: |
-          nix build .\#nemo{,-doc,-language-server,-python,-vscode-extension,-wasm-bundler,-wasm-node,-wasm-web,-web}
+          nix build .\#{nemo{,-doc,-language-server,-python,-vscode-extension,-wasm-bundler,-wasm-node,-wasm-web,-web},docker}
           nix-store --optimise
           nix-collect-garbage -d
+
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push docker image 
+        run: |
+          nix build .\#docker
+          docker load < result
+          docker image tag nemo:latest ${{ env.REGISTRY }}/knowsys/nemo:latest
+          docker push ${{ env.REGISTRY }}/knowsys/nemo:latest
+

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
     tags:
       - "v*.*.*"
 
+env:
+  REGISTRY: ghcr.io
+
 jobs:
   release:
     name: release ${{ matrix.platform.os-name }}
@@ -68,6 +71,36 @@ jobs:
           else
             sha256sum "$asset" > "$asset.sha256sum"
           fi
+
+      - uses: cachix/install-nix-action@v31
+      - uses: jlumbroso/free-disk-space@v1.3.1
+        with:
+          swap-storage: false
+          tool-cache: true
+      - name: Restore and save Nix store
+        uses: nix-community/cache-nix-action@v6
+        with:
+          primary-key: nemo-nix-${{ runner.os }}-${{ hashFiles('**/*.nix', '**/flake.lock') }}
+          restore-prefixes-first-match: nemo-nix-${{ runner.os }}-
+          gc-max-store-size-linux: 2.5G
+          purge: true
+          purge-prefixes: nemo-nix-${{ runner.os }}-
+          purge-created: 0
+          purge-last-accessed: 0
+          purge-primary-key: never
+      - name: Log in to the Container registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Build and push docker image 
+        run: |
+          nix build .\#docker
+          docker load < result
+          docker image tag nemo:latest ${{ env.REGISTRY }}/knowsys/nemo:${{ github.ref_name }}
+          docker push ${{ env.REGISTRY }}/knowsys/nemo:${{ github.ref_name }}
+
       - name: Create (draft) release
         uses: softprops/action-gh-release@v2
         with:

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1748047550,
-        "narHash": "sha256-t0qLLqb4C1rdtiY8IFRH5KIapTY/n3Lqt57AmxEv9mk=",
+        "lastModified": 1748970125,
+        "narHash": "sha256-UDyigbDGv8fvs9aS95yzFfOKkEjx1LO3PL3DsKopohA=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "b718a78696060df6280196a6f992d04c87a16aef",
+        "rev": "323b5746d89e04b22554b061522dfce9e4c49b18",
         "type": "github"
       },
       "original": {
@@ -54,11 +54,11 @@
         "pyproject-nix": "pyproject-nix"
       },
       "locked": {
-        "lastModified": 1747658429,
-        "narHash": "sha256-qZWuEdxmPx818qR61t3mMozJOvZSmTRUDPU4L3JeGgE=",
+        "lastModified": 1748838242,
+        "narHash": "sha256-wORL3vLIJdBF8hz73yuD7DVsrbOvFgtH96hQIetXhfg=",
         "owner": "nix-community",
         "repo": "dream2nix",
-        "rev": "6fd6d9188f32efd1e1656b3c3e63a67f9df7b636",
+        "rev": "e92dacdc57acaa6b2ae79592c1a62c2340931410",
         "type": "github"
       },
       "original": {
@@ -720,11 +720,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748302896,
-        "narHash": "sha256-ixMT0a8mM091vSswlTORZj93WQAJsRNmEvqLL+qwTFM=",
+        "lastModified": 1748889542,
+        "narHash": "sha256-Hb4iMhIbjX45GcrgOp3b8xnyli+ysRPqAgZ/LZgyT5k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7848cd8c982f7740edf76ddb3b43d234cb80fc4d",
+        "rev": "10d7f8d34e5eb9c0f9a0485186c1ca691d2c5922",
         "type": "github"
       },
       "original": {
@@ -951,11 +951,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1748399823,
-        "narHash": "sha256-kahD8D5hOXOsGbNdoLLnqCL887cjHkx98Izc37nDjlA=",
+        "lastModified": 1749004659,
+        "narHash": "sha256-zaZrcC5UwHPGkgfnhTPx5sZfSSnUJdvYHhgex10RadQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "d68a69dc71bc19beb3479800392112c2f6218159",
+        "rev": "c52e346aedfa745564599558a096e88f9a5557f9",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -323,6 +323,20 @@
               };
             };
 
+            docker = pkgs.dockerTools.buildImage {
+              name = "nemo";
+              tag = "latest";
+              copyToRoot = pkgs.buildEnv {
+                name = "image-root";
+                paths = [ 
+                  pkgs.cacert
+                  pkgs.openssl
+                  nemo
+                ];
+              };
+              config = { Entrypoint = [ "/bin/nmo" ]; };
+            };
+
             nemo-language-server = buildCrate { crate = "nemo-language-server"; };
 
             nemo-python = buildCrate {

--- a/nemo-physical/src/aggregates/processors/sum_aggregate.rs
+++ b/nemo-physical/src/aggregates/processors/sum_aggregate.rs
@@ -111,12 +111,10 @@ impl AggregateGroupProcessor for SumAggregateGroupProcessor {
             }
 
             Some(overall_sum.into())
-        } else if let Some(current_sum_i64) = self.current_sum_i64 {
-            return Some(current_sum_i64.into());
-        } else if let Some(current_sum_f32) = self.current_sum_f32 {
-            return Some(current_sum_f32.into());
         } else {
-            None
+            self.current_sum_i64
+                .map(Into::into)
+                .or_else(|| self.current_sum_f32.map(Into::into))
         }
     }
 }

--- a/nemo-physical/src/datavalues/any_datavalue.rs
+++ b/nemo-physical/src/datavalues/any_datavalue.rs
@@ -435,22 +435,22 @@ impl AnyDataValue {
             }
         } else if let DecimalType::Decimal = decimal_type {
             if has_nonzero_fraction {
-                return Ok(AnyDataValue::new_other(
+                Ok(AnyDataValue::new_other(
                     trimmed_value,
                     XSD_PREFIX.to_owned() + "decimal",
-                ));
+                ))
             } else if let Ok(value) = i64::from_str(&trimmed_value) {
-                return Ok(AnyDataValue::new_integer_from_i64(value));
+                Ok(AnyDataValue::new_integer_from_i64(value))
             } else if let Ok(value) = u64::from_str(&trimmed_value) {
-                return Ok(AnyDataValue::new_integer_from_u64(value));
+                Ok(AnyDataValue::new_integer_from_u64(value))
             } else {
-                return Ok(AnyDataValue::new_other(
+                Ok(AnyDataValue::new_other(
                     trimmed_value,
                     XSD_PREFIX.to_owned() + "integer",
-                ));
+                ))
             }
         } else {
-            return Self::decimal_parse_error(lexical_value, decimal_type);
+            Self::decimal_parse_error(lexical_value, decimal_type)
         }
     }
 

--- a/nemo-physical/src/datavalues/integer_datavalues.rs
+++ b/nemo-physical/src/datavalues/integer_datavalues.rs
@@ -53,11 +53,11 @@ impl DataValue for UnsignedLongDataValue {
         if self.0 <= I32MAX_AS_U64 {
             ValueDomain::NonNegativeInt
         } else if self.0 <= U32MAX_AS_U64 {
-            return ValueDomain::UnsignedInt;
+            ValueDomain::UnsignedInt
         } else if self.0 <= I64MAX_AS_U64 {
-            return ValueDomain::NonNegativeLong;
+            ValueDomain::NonNegativeLong
         } else {
-            return ValueDomain::UnsignedLong;
+            ValueDomain::UnsignedLong
         }
     }
 
@@ -138,14 +138,14 @@ impl DataValue for LongDataValue {
             if self.0 <= I32MAX_AS_I64 {
                 ValueDomain::NonNegativeInt
             } else if self.0 <= U32MAX_AS_I64 {
-                return ValueDomain::UnsignedInt;
+                ValueDomain::UnsignedInt
             } else {
-                return ValueDomain::NonNegativeLong;
+                ValueDomain::NonNegativeLong
             }
         } else if self.0 >= I32MIN_AS_I64 {
-            return ValueDomain::Int;
+            ValueDomain::Int
         } else {
-            return ValueDomain::Long;
+            ValueDomain::Long
         }
     }
 

--- a/nemo/src/io/format_builder.rs
+++ b/nemo/src/io/format_builder.rs
@@ -74,6 +74,8 @@ pub(super) fn value_type_matches(
 pub(crate) trait FormatTag:
     FromStr<Err = ()> + ToString + Copy + Eq + 'static + Into<SupportedFormatTag>
 {
+    // NOTE: the only implementations of this trait happen in macros and are for some reason not recognized
+    #[allow(dead_code)]
     const VARIANTS: &'static [(Self, &'static str)];
 }
 


### PR DESCRIPTION
Fixes #689 

This PR allows to build a docker image with `nix build .#docker`. On top, every commit on the main branch triggers the build of this image and pushes it to the Github Container Registry of this project with the `latest` tag.
Every git tag (aka. release) will also trigger a build tagging the docker image with the respective version (e.g. v.0.8.0 instead of latest). **This is currently not tested and I propose we check this when we do the next release.**

For example, the docker image from the registry can be used as follows:
```podman run --rm -t -v .:/pwd ghcr.io/knowsys/nemo:latest /pwd/test.rls -e idb -D /pwd/docker-results```
(The same should work with `docker` instead of `podman`.)
This already works right now as I did a test build/push from this branch tagging the image as `latest`. In the future this will only happen on `main`.