### PR TITLE
Mimic cli pipeline in wasm code

### DIFF
--- a/nemo/src/rule_model/pipeline/transformations.rs
+++ b/nemo/src/rule_model/pipeline/transformations.rs
@@ -7,6 +7,7 @@ pub mod exports;
 pub mod filter_imports;
 pub mod global;
 pub mod incremental;
+pub mod set_default_outputs;
 pub mod skolem;
 pub mod split;
 pub mod validate;

--- a/nemo/src/rule_model/pipeline/transformations/default.rs
+++ b/nemo/src/rule_model/pipeline/transformations/default.rs
@@ -8,7 +8,8 @@ use crate::{
         error::ValidationReport,
         pipeline::transformations::{
             active::TransformationActive, empty::TransformationEmpty,
-            incremental::TransformationIncremental, validate::TransformationValidate,
+            incremental::TransformationIncremental,
+            set_default_outputs::TransformationSetDefaultOutputs, validate::TransformationValidate,
         },
         programs::{ProgramRead, handle::ProgramHandle},
     },
@@ -48,6 +49,7 @@ impl<'a> ProgramTransformation for TransformationDefault<'a> {
         commit
             .submit()?
             .transform(TransformationGlobal::new(&self.parameters.global_variables))?
+            .transform(TransformationSetDefaultOutputs::default())?
             .transform(TransformationExports::new(
                 self.parameters.export_parameters,
             ))?

--- a/nemo/src/rule_model/pipeline/transformations/default.rs
+++ b/nemo/src/rule_model/pipeline/transformations/default.rs
@@ -49,10 +49,10 @@ impl<'a> ProgramTransformation for TransformationDefault<'a> {
         commit
             .submit()?
             .transform(TransformationGlobal::new(&self.parameters.global_variables))?
-            .transform(TransformationSetDefaultOutputs::default())?
             .transform(TransformationExports::new(
                 self.parameters.export_parameters,
             ))?
+            .transform(TransformationSetDefaultOutputs::default())?
             // .transform(TransformationFilterImports::new())? // Feature not yet implemented
             .transform(TransformationIncremental::new())?
             .transform(TransformationEmpty::new())?

--- a/nemo/src/rule_model/pipeline/transformations/set_default_outputs.rs
+++ b/nemo/src/rule_model/pipeline/transformations/set_default_outputs.rs
@@ -20,7 +20,7 @@ impl ProgramTransformation for TransformationSetDefaultOutputs {
 
         program.statements().for_each(|s| commit.keep(s));
 
-        if program.outputs().next().is_none() {
+        if program.outputs().next().is_none() && program.exports().next().is_none() {
             for predicate in program.all_predicates() {
                 commit.add_output(Output::new(predicate))
             }

--- a/nemo/src/rule_model/pipeline/transformations/set_default_outputs.rs
+++ b/nemo/src/rule_model/pipeline/transformations/set_default_outputs.rs
@@ -1,0 +1,31 @@
+//! This module defines [TransformationSetDefaultOutputs].
+
+use crate::rule_model::{
+    components::output::Output,
+    error::ValidationReport,
+    programs::{ProgramRead, ProgramWrite, handle::ProgramHandle},
+};
+
+use super::ProgramTransformation;
+
+/// Program transformation
+///
+/// If no output predicates have been specified, then all predicates are set as outputs.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct TransformationSetDefaultOutputs {}
+
+impl ProgramTransformation for TransformationSetDefaultOutputs {
+    fn apply(self, program: &ProgramHandle) -> Result<ProgramHandle, ValidationReport> {
+        let mut commit = program.fork();
+
+        program.statements().for_each(|s| commit.keep(s));
+
+        if program.outputs().next().is_none() {
+            for predicate in program.all_predicates() {
+                commit.add_output(Output::new(predicate))
+            }
+        }
+
+        commit.submit()
+    }
+}


### PR DESCRIPTION
The wasm code now behaves similar to `ExecutionEngine::from_file` used in the CLI.
We cannot directly use this function though as we need access to the parsed program before creating the execution engine. This is because we need to create a special import manager for the web where we load preload resources using the browser. To know which resources to load, we already need access to the parsed program but the execution engine already needs to know the import manager on creation. Thus we have a bit of a chicken-egg problem here that we solve by duplicating the logic of the `ExecutionEngine::from_file` in the WASM code.

Furthermore, this PR adds a default transformation that in spirit was already used on the web before:
If no `@output` directives are set, then all predicates are added as outputs.

This PR builds on top of #701 