### PR TITLE
Only output derived predicates

### DIFF
--- a/nemo/src/rule_model/pipeline/transformations/set_default_outputs.rs
+++ b/nemo/src/rule_model/pipeline/transformations/set_default_outputs.rs
@@ -21,7 +21,7 @@ impl ProgramTransformation for TransformationSetDefaultOutputs {
         program.statements().for_each(|s| commit.keep(s));
 
         if program.outputs().next().is_none() && program.exports().next().is_none() {
-            for predicate in program.all_predicates() {
+            for predicate in program.derived_predicates() {
                 commit.add_output(Output::new(predicate))
             }
         }


### PR DESCRIPTION
When the user doesn't mark any predicate with `@output` or `@export`, then we automatically assume that everything should be computed by marking every predicate with `@output`.

However, this should not extend to edb predicates, as marking those as output-predicates prevents certain optimizations.