### PR TITLE
Paging for SPARQL queries

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -657,11 +657,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1752613317,
-        "narHash": "sha256-SPS/iE8RdqmlWeREDa9/k2dgziiaAJU3kDknuHYdGZk=",
+        "lastModified": 1758632847,
+        "narHash": "sha256-/BJTeCsBMx20S+N+V4aOd1O/LlKhr8BzpXuY6lfoTfs=",
         "owner": "knowsys",
         "repo": "nemo-vscode-extension",
-        "rev": "3cf4f338c86d29667bda2f79f2cc7a040978f9c2",
+        "rev": "3f4a199b334eafc61ac26e5e423187ada00887bf",
         "type": "github"
       },
       "original": {
@@ -1506,11 +1506,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758270272,
-        "narHash": "sha256-8bSqHKwu4SnoJJS++HTPGwOSt+aKM/6i52dpFncnI88=",
+        "lastModified": 1758627028,
+        "narHash": "sha256-Ne/VAqd9oIvwT7KChbou8gh6Of816xtMrCuGIg1v4Vw=",
         "owner": "knowsys",
         "repo": "nemo-web",
-        "rev": "8312f05fe4a77eb3e8f0d69af1604c4034ed1a37",
+        "rev": "cfdc5edbb07dc08480ea4ee0d8b5c3539d6266ba",
         "type": "github"
       },
       "original": {
@@ -1731,11 +1731,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1758070117,
-        "narHash": "sha256-uLwwHFCZnT1c3N3biVe/0hCkag2GSrf9+M56+Okf+WY=",
+        "lastModified": 1758589230,
+        "narHash": "sha256-zMTCFGe8aVGTEr2RqUi/QzC1nOIQ0N1HRsbqB4f646k=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e9b7f2ff62b35f711568b1f0866243c7c302028d",
+        "rev": "d1d883129b193f0b495d75c148c2c3a7d95789a0",
         "type": "github"
       },
       "original": {
@@ -2224,11 +2224,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1758249250,
-        "narHash": "sha256-bg228atm49IZ8koNOlT3bsrFKE9sFjq6vn6Tx8eVgpc=",
+        "lastModified": 1758594771,
+        "narHash": "sha256-loYxdliGF/ytyAorc36Tt/PwBpc2rAfMSJycNxc2oeg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "e26a009e7edab102bd569dc041459deb6c0009f4",
+        "rev": "96722b8da34a7d796668b9a1cbcb7e799cc524b5",
         "type": "github"
       },
       "original": {

--- a/nemo-physical/src/error.rs
+++ b/nemo-physical/src/error.rs
@@ -91,6 +91,11 @@ impl ReadingError {
         self.predicate = Some(predicate);
         self
     }
+
+    /// Return the underlying [ReadingErrorKind]
+    pub fn kind(self) -> ReadingErrorKind {
+        self.kind
+    }
 }
 
 impl<T> From<T> for ReadingError

--- a/nemo/src/io/formats/sparql.rs
+++ b/nemo/src/io/formats/sparql.rs
@@ -16,8 +16,8 @@ use oxiri::Iri;
 use crate::{
     chase_model::components::rule::ChaseRule,
     io::format_builder::{
-        format_parameter, format_tag, value_type_matches, AnyImportExportBuilder, FormatParameter,
-        Parameters, StandardParameter, SupportedFormatTag,
+        AnyImportExportBuilder, FormatParameter, Parameters, StandardParameter, SupportedFormatTag,
+        format_parameter, format_tag, value_type_matches,
     },
     rule_model::{
         components::{import_export::Direction, term::value_type::ValueType},
@@ -263,9 +263,9 @@ impl ImportHandler for SparqlHandler {
 #[cfg(test)]
 mod test {
     use crate::parser::{
-        ast::{directive::import::Import, ProgramAST},
-        input::ParserInput,
         ParserState,
+        ast::{ProgramAST, directive::import::Import},
+        input::ParserInput,
     };
     use nom::combinator::all_consuming;
 

--- a/nemo/src/io/formats/sparql.rs
+++ b/nemo/src/io/formats/sparql.rs
@@ -16,8 +16,8 @@ use oxiri::Iri;
 use crate::{
     chase_model::components::rule::ChaseRule,
     io::format_builder::{
-        AnyImportExportBuilder, FormatParameter, Parameters, StandardParameter, SupportedFormatTag,
-        format_parameter, format_tag, value_type_matches,
+        format_parameter, format_tag, value_type_matches, AnyImportExportBuilder, FormatParameter,
+        Parameters, StandardParameter, SupportedFormatTag,
     },
     rule_model::{
         components::{import_export::Direction, term::value_type::ValueType},
@@ -34,7 +34,13 @@ use super::{ExportHandler, FileFormatMeta, FormatBuilder, ImportHandler};
 use crate::io::formats::dsv::value_format::DsvValueFormats;
 
 /// A char limit to decide if a query is send as GET or POST request
-const HTTP_GET_CHAR_LIMIT: usize = 2000;
+const HTTP_GET_CHAR_LIMIT: usize = 2_000;
+
+/// How many bindings to push into a single query
+const MAX_BINDINGS_PER_PAGE: usize = 32_000;
+
+/// How many characters can fit into a single query page
+const QUERY_PAGE_CHAR_LIMIT: usize = 740_000;
 
 format_tag! {
     pub enum SparqlTag(SupportedFormatTag::Sparql) {
@@ -257,9 +263,9 @@ impl ImportHandler for SparqlHandler {
 #[cfg(test)]
 mod test {
     use crate::parser::{
-        ParserState,
-        ast::{ProgramAST, directive::import::Import},
+        ast::{directive::import::Import, ProgramAST},
         input::ParserInput,
+        ParserState,
     };
     use nom::combinator::all_consuming;
 

--- a/nemo/src/io/formats/sparql/reader.rs
+++ b/nemo/src/io/formats/sparql/reader.rs
@@ -98,7 +98,7 @@ impl SparqlReader {
                 && let Some(code) = error.status() && code == reqwest::StatusCode::PAYLOAD_TOO_LARGE
             {
                 // the page size is still too large, try half
-                for page in page.chunks(page.len().div_ceil(2)) {
+                for page in page.chunks(page.len().div_ceil(2).max(1)) {
                     Box::pin(self.load_from_bindings(bound_positions, page, tuple_writer)).await?;
                 }
             }
@@ -239,7 +239,7 @@ impl SparqlReader {
     ) -> impl Iterator<Item = (&'bindings [Vec<AnyDataValue>], Query)> {
         let mut queries = Vec::new();
 
-        for page in bindings.chunks(page_size) {
+        for page in bindings.chunks(page_size.max(1)) {
             match self.query_with_bindings(bound_positions, page) {
                 Some(query) => {
                     queries.push((page, query));

--- a/nemo/src/io/resource_providers/http.rs
+++ b/nemo/src/io/resource_providers/http.rs
@@ -114,6 +114,7 @@ impl HttpResourceProvider {
         } else {
             client.post(full_url.clone()).form(&post_parameters)
         };
+
         let response = request_builder
             .send()
             .await


### PR DESCRIPTION
Instead of pushing all of the bindings at once, split into multiple smaller queries if needed. This works with a static upper limit for the query size (currently 740 kb, which seems to _just_ fit for WDQS), and also properly handles `HTTP 413 Request Too Large` responses from the endpoint.

With this, the following program now successfully runs and fetches the given names for some 50000 humans in a total of 5 queries (one for the persons, and then 4 different sets of bindings).

```prolog
@prefix wdqs: <https://query.wikidata.org/> .
@prefix wd: <http://www.wikidata.org/entity/> .
@prefix wdt: <http://www.wikidata.org/prop/direct/> .

@import persons :- sparql{
  endpoint = wdqs:sparql,
  query = """
    PREFIX wd: <http://www.wikidata.org/entity/>
    PREFIX wdt: <http://www.wikidata.org/prop/direct/>
    SELECT ?s WHERE {
      ?s wdt:P31 wd:Q5
    } LIMIT 50000
  """
} .

@import names :- sparql{
  endpoint = wdqs:sparql,
  query = """
    PREFIX wdt: <http://www.wikidata.org/prop/direct/>
    SELECT ?s ?o WHERE {
      ?s wdt:P735 ?o
    }
  """
} .

% we need to proxy the persons, since import chains are currently not internalised.
people(?s) :- persons(?s) .

peopleNames(?s, ?n) :- people(?s), names(?s, ?n) .

@export peopleNames :- csv{} .
```