### PR TITLE
Fix transformation order

### DIFF
--- a/nemo/src/rule_model/pipeline/transformations/default.rs
+++ b/nemo/src/rule_model/pipeline/transformations/default.rs
@@ -58,8 +58,8 @@ impl<'a> ProgramTransformation for TransformationDefault<'a> {
             .transform(TransformationSetDefaultOutputs::default())?
             .transform(TransformationValidate::default())?
             .transform(TransformationActive::default())?
-            .transform(TransformationFilterImports::new())?
             .transform(TransformationIncremental::new())?
+            .transform(TransformationFilterImports::new())?
             .transform(TransformationEmpty::new())
     }
 }


### PR DESCRIPTION
This small fix prevents incremental imports from being blocked by import filters, and ensures that inactive rules get removed before everything else.