### PR TITLE
Handle auxiliary variables in filter/transform patterns

### DIFF
--- a/nemo-physical/src/function/definitions.rs
+++ b/nemo-physical/src/function/definitions.rs
@@ -129,7 +129,7 @@ pub(crate) trait UnaryFunction {
 }
 
 /// Enum containing all implementations of [UnaryFunction]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum UnaryFunctionEnum {
     BooleanNegation(BooleanNegation),
     CanonicalString(CanonicalString),
@@ -222,7 +222,7 @@ pub trait BinaryFunction {
 }
 
 /// Enum containing all implementations of [BinaryFunction]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum BinaryFunctionEnum {
     Equals(Equals),
     Unequals(Unequals),
@@ -306,7 +306,7 @@ pub trait TernaryFunction {
 }
 
 /// Enum containing all implementations of [TernaryFunction]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TernaryFunctionEnum {
     StringSubstringLength(StringSubstringLength),
 }
@@ -335,7 +335,7 @@ pub trait NaryFunction {
 }
 
 /// Enum containing all implementations of [NaryFunction]
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum NaryFunctionEnum {
     BitAnd(BitAnd),
     BitOr(BitOr),

--- a/nemo-physical/src/function/definitions/boolean.rs
+++ b/nemo-physical/src/function/definitions/boolean.rs
@@ -25,7 +25,7 @@ fn bool_list_from_any(parameters: &[AnyDataValue]) -> Option<Vec<bool>> {
 ///
 /// Returns `true` if no parameters are given.
 /// Returns `None` if one of the inputs is not in the boolean value range.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BooleanConjunction;
 impl NaryFunction for BooleanConjunction {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {
@@ -53,7 +53,7 @@ impl NaryFunction for BooleanConjunction {
 ///
 /// Returns `false` if no parameters are given.
 /// Returns `None` if one of the inputs is not in the boolean value range.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BooleanDisjunction;
 impl NaryFunction for BooleanDisjunction {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {
@@ -81,7 +81,7 @@ impl NaryFunction for BooleanDisjunction {
 /// and returns `false` if its input it `true`.
 ///
 /// Returns `None` if the input is not in the boolean value range.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BooleanNegation;
 impl UnaryFunction for BooleanNegation {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {

--- a/nemo-physical/src/function/definitions/casting.rs
+++ b/nemo-physical/src/function/definitions/casting.rs
@@ -22,7 +22,7 @@ use super::{FunctionTypePropagation, UnaryFunction};
 ///
 /// Returns `None` when called on values outside the range described above
 /// or if the value cannot be converted to an integer.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CastingIntoInteger64;
 impl UnaryFunction for CastingIntoInteger64 {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -107,7 +107,7 @@ impl UnaryFunction for CastingIntoInteger64 {
 ///
 /// Returns `None` when called on values outside the range described above
 /// or if value cannot be converted into a 32-bit float.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CastingIntoFloat;
 impl UnaryFunction for CastingIntoFloat {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -167,7 +167,7 @@ impl UnaryFunction for CastingIntoFloat {
 ///
 /// Returns `None` when called on values outside the range described above
 /// or if value cannot be converted into a 64-bit float.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CastingIntoDouble;
 impl UnaryFunction for CastingIntoDouble {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -218,7 +218,7 @@ impl UnaryFunction for CastingIntoDouble {
 /// Returns an IRI with the same content as the given string.
 ///
 /// Returns `None` when called on values other than plain strings.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CastingIntoIri;
 impl UnaryFunction for CastingIntoIri {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {

--- a/nemo-physical/src/function/definitions/checktype.rs
+++ b/nemo-physical/src/function/definitions/checktype.rs
@@ -10,7 +10,7 @@ use super::{FunctionTypePropagation, UnaryFunction};
 /// Check if value is integer
 ///
 /// Returns "true" from the boolean value space if value is an integer and "false" otherwise.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CheckIsInteger;
 impl UnaryFunction for CheckIsInteger {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -34,7 +34,7 @@ impl UnaryFunction for CheckIsInteger {
 /// Check if value is float
 ///
 /// Returns "true" from the boolean value space if value is a float and "false" otherwise.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CheckIsFloat;
 impl UnaryFunction for CheckIsFloat {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -58,7 +58,7 @@ impl UnaryFunction for CheckIsFloat {
 /// Check if value is double
 ///
 /// Returns "true" from the boolean value space if value is a double and "false" otherwise.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CheckIsDouble;
 impl UnaryFunction for CheckIsDouble {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -82,7 +82,7 @@ impl UnaryFunction for CheckIsDouble {
 /// Check if value is numeric
 ///
 /// Returns "true" from the boolean value space if value is numeric and "false" otherwise.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CheckIsNumeric;
 impl UnaryFunction for CheckIsNumeric {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -109,7 +109,7 @@ impl UnaryFunction for CheckIsNumeric {
 /// Check if value is a null
 ///
 /// Returns "true" from the boolean value space if value is a null and "false" otherwise.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CheckIsNull;
 impl UnaryFunction for CheckIsNull {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -133,7 +133,7 @@ impl UnaryFunction for CheckIsNull {
 /// Check if value is an iri
 ///
 /// Returns "true" from the boolean value space if value is an iri and "false" otherwise.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CheckIsIri;
 impl UnaryFunction for CheckIsIri {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -157,7 +157,7 @@ impl UnaryFunction for CheckIsIri {
 /// Check if value is a string
 ///
 /// Returns "true" from the boolean value space if value is a string and "false" otherwise.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CheckIsString;
 impl UnaryFunction for CheckIsString {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {

--- a/nemo-physical/src/function/definitions/generic.rs
+++ b/nemo-physical/src/function/definitions/generic.rs
@@ -11,7 +11,7 @@ use super::{BinaryFunction, FunctionTypePropagation, UnaryFunction};
 ///
 /// Returns `true` from the boolean value space
 /// if both input values are equal and `false` if they are not.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Equals;
 impl BinaryFunction for Equals {
     fn evaluate(
@@ -40,7 +40,7 @@ impl BinaryFunction for Equals {
 ///
 /// Returns `false` from the boolean value space
 /// if both input values are equal and `true` if they are not.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Unequals;
 impl BinaryFunction for Unequals {
     fn evaluate(
@@ -68,7 +68,7 @@ impl BinaryFunction for Unequals {
 /// Canonical string representation
 ///
 /// Returns the canonical string representation of the given value
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct CanonicalString;
 impl UnaryFunction for CanonicalString {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -87,7 +87,7 @@ impl UnaryFunction for CanonicalString {
 /// Lexical value
 ///
 /// Return the lexical value of the given value as a string.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct LexicalValue;
 impl UnaryFunction for LexicalValue {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -115,7 +115,7 @@ impl UnaryFunction for LexicalValue {
 /// Datatype of a value
 ///
 /// Returns the data type of the input parameter as a string.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct Datatype;
 impl UnaryFunction for Datatype {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {

--- a/nemo-physical/src/function/definitions/language.rs
+++ b/nemo-physical/src/function/definitions/language.rs
@@ -12,7 +12,7 @@ use super::{FunctionTypePropagation, UnaryFunction};
 /// Returns the language tag as a string of a language tagged string.
 /// Returns the empty string if value is a string.
 /// Returns `None` if value is neither string nor language tagged string.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct LanguageTag;
 impl UnaryFunction for LanguageTag {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -37,7 +37,7 @@ impl UnaryFunction for LanguageTag {
 /// the first being the tagged string and the second the language tag.
 ///
 /// Returns `None` if the input parameters are not strings.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct LanguageString;
 impl BinaryFunction for LanguageString {
     fn evaluate(

--- a/nemo-physical/src/function/definitions/numeric.rs
+++ b/nemo-physical/src/function/definitions/numeric.rs
@@ -307,7 +307,7 @@ impl NumericList {
 ///
 /// Returns `None` if the input parameters are not numeric
 /// or if the result cannot be represented within the range of the result's value type.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericAddition;
 impl BinaryFunction for NumericAddition {
     fn evaluate(
@@ -337,7 +337,7 @@ impl BinaryFunction for NumericAddition {
 ///
 /// Returns `None` if the input parameters are not numeric
 /// or if the result cannot be represented within the range of the result's value type.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericSubtraction;
 impl BinaryFunction for NumericSubtraction {
     fn evaluate(
@@ -367,7 +367,7 @@ impl BinaryFunction for NumericSubtraction {
 ///
 /// Returns `None` if the input parameters are not numeric
 /// or if the result cannot be represented within the range of the result's value type.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericMultiplication;
 impl BinaryFunction for NumericMultiplication {
     fn evaluate(
@@ -399,7 +399,7 @@ impl BinaryFunction for NumericMultiplication {
 ///
 /// Returns `None` if the input parameters are not numeric
 /// or if the result cannot be represented within the range of the result's value type.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericDivision;
 impl BinaryFunction for NumericDivision {
     fn evaluate(
@@ -429,7 +429,7 @@ impl BinaryFunction for NumericDivision {
 /// returns the integer resulting from perfoming an "and" on their bit representation.
 ///
 /// Returns `None` if the input parameters are not integers or no input parameters are given.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BitAnd;
 impl NaryFunction for BitAnd {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {
@@ -455,7 +455,7 @@ impl NaryFunction for BitAnd {
 ///
 /// Returns the zero from the integer value space if no parameters are given.
 /// Returns `None` if the input parameters are not integers or no input parameters are given.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BitOr;
 impl NaryFunction for BitOr {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {
@@ -481,7 +481,7 @@ impl NaryFunction for BitOr {
 ///
 /// Returns zero from the integer value space if no parameters are given.
 /// Returns `None` if the input parameters are not integers or no input parameters are given.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BitXor;
 impl NaryFunction for BitXor {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {
@@ -503,7 +503,7 @@ impl NaryFunction for BitXor {
 /// Bitwise Left shift
 ///
 /// Returns `None` if the input parameter pair are not integers or no input parameters are given.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BitShiftLeft;
 impl BinaryFunction for BitShiftLeft {
     fn evaluate(
@@ -525,7 +525,7 @@ impl BinaryFunction for BitShiftLeft {
 /// Bitwise arithmetic right shift
 ///
 /// Returns `None` if the input parameter pair are not integers or no input parameters are given.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BitShiftRight;
 impl BinaryFunction for BitShiftRight {
     fn evaluate(
@@ -547,7 +547,7 @@ impl BinaryFunction for BitShiftRight {
 /// Bitwise logical (unsigned) right shift
 ///
 /// Returns `None` if the input parameter pair are not integers or no input parameters are given.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct BitShiftRightUnsigned;
 impl BinaryFunction for BitShiftRightUnsigned {
     fn evaluate(
@@ -573,7 +573,7 @@ impl BinaryFunction for BitShiftRightUnsigned {
 ///
 /// Returns `None` if the input parameters are not numeric
 /// or if the result cannot be represented within the range of the result's value type.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericLogarithm;
 impl BinaryFunction for NumericLogarithm {
     fn evaluate(
@@ -603,7 +603,7 @@ impl BinaryFunction for NumericLogarithm {
 ///
 /// Returns `None` if the input parameters are not numeric
 /// or if the result cannot be represented within the range of the result's value type.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericPower;
 impl BinaryFunction for NumericPower {
     fn evaluate(
@@ -636,7 +636,7 @@ impl BinaryFunction for NumericPower {
 ///
 /// Returns `None` if the input parameters are not numeric
 /// or if the result cannot be represented within the range of the result's value type.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericRemainder;
 impl BinaryFunction for NumericRemainder {
     fn evaluate(
@@ -665,7 +665,7 @@ impl BinaryFunction for NumericRemainder {
 /// Returns the absolute value of the given parameter.
 ///
 /// Returns `None` if the input parameter is not a numeric value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericAbsolute;
 impl UnaryFunction for NumericAbsolute {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -690,7 +690,7 @@ impl UnaryFunction for NumericAbsolute {
 /// Returns the multiplicative inverse of the input paramter.
 ///
 /// Returns `None` if the input parameter is not a numeric value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericNegation;
 impl UnaryFunction for NumericNegation {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -716,7 +716,7 @@ impl UnaryFunction for NumericNegation {
 ///
 /// Returns `None` if the input parameter is not a numeric value space
 /// or is negative.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericSquareroot;
 impl UnaryFunction for NumericSquareroot {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -741,7 +741,7 @@ impl UnaryFunction for NumericSquareroot {
 /// Returns the sine of the input parameter.
 ///
 /// Returns `None` if the input paramter is not in a floating point value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericSine;
 impl UnaryFunction for NumericSine {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -766,7 +766,7 @@ impl UnaryFunction for NumericSine {
 /// Returns the cosine of the input parameter.
 ///
 /// Returns `None` if the input paramter is not in a floating point value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericCosine;
 impl UnaryFunction for NumericCosine {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -791,7 +791,7 @@ impl UnaryFunction for NumericCosine {
 /// Returns the tangent of the input parameter.
 ///
 /// Returns `None` if the input paramter is not in a floating point value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericTangent;
 impl UnaryFunction for NumericTangent {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -817,7 +817,7 @@ impl UnaryFunction for NumericTangent {
 /// If the result is half-way between two integers, round away from 0.0.
 ///
 /// Returns `None` if the input parameter is not from a numeric value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericRound;
 impl UnaryFunction for NumericRound {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -842,7 +842,7 @@ impl UnaryFunction for NumericRound {
 /// Returns the smallest integer less than or equal than input parameter
 ///
 /// Returns `None` if the input parameter is not from a numeric value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericCeil;
 impl UnaryFunction for NumericCeil {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -868,7 +868,7 @@ impl UnaryFunction for NumericCeil {
 /// If the result is half-way between two integers, round away from 0.0.
 ///
 /// Returns `None` if the input parameter is not from a numeric value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericFloor;
 impl UnaryFunction for NumericFloor {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -895,7 +895,7 @@ impl UnaryFunction for NumericFloor {
 /// and `false` otherwise.
 ///
 /// Returns `None` if the arguments are not from the numeric value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericLessthan;
 impl BinaryFunction for NumericLessthan {
     fn evaluate(
@@ -931,7 +931,7 @@ impl BinaryFunction for NumericLessthan {
 /// and `false` otherwise.
 ///
 /// Returns `None` if the arguments are not from the numeric value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericLessthaneq;
 impl BinaryFunction for NumericLessthaneq {
     fn evaluate(
@@ -967,7 +967,7 @@ impl BinaryFunction for NumericLessthaneq {
 /// and `false` otherwise.
 ///
 /// Returns `None` if the arguments are not from the numeric value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericGreaterthan;
 impl BinaryFunction for NumericGreaterthan {
     fn evaluate(
@@ -1003,7 +1003,7 @@ impl BinaryFunction for NumericGreaterthan {
 /// and `false` otherwise.
 ///
 /// Returns `None` if the arguments are not from the numeric value space.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericGreaterthaneq;
 impl BinaryFunction for NumericGreaterthaneq {
     fn evaluate(
@@ -1042,7 +1042,7 @@ impl BinaryFunction for NumericGreaterthaneq {
 /// or no input parameters are given.
 /// Returns `None` if the result (or an intermediate result) cannot be represented
 /// within the range of the numeric value type.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericSum;
 impl NaryFunction for NumericSum {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {
@@ -1070,7 +1070,7 @@ impl NaryFunction for NumericSum {
 /// or no input parameters are given.
 /// Returns `None` if the result (or an intermediate result) cannot be represented
 /// within the range of the numeric value type.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericProduct;
 impl NaryFunction for NumericProduct {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {
@@ -1096,7 +1096,7 @@ impl NaryFunction for NumericProduct {
 ///
 /// Returns `None` if the input parameters are not numeric
 /// or no input parameters are given.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericMinimum;
 impl NaryFunction for NumericMinimum {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {
@@ -1122,7 +1122,7 @@ impl NaryFunction for NumericMinimum {
 ///
 /// Returns `None` if the input parameters are not numeric
 /// or no input parameters are given.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericMaximum;
 impl NaryFunction for NumericMaximum {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {
@@ -1149,7 +1149,7 @@ impl NaryFunction for NumericMaximum {
 /// Returns `None` if the input parameters are not numeric
 /// or no input parameters are given.
 /// Returns `None` if the input parameters are not of a floating point type.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct NumericLukasiewicz;
 impl NaryFunction for NumericLukasiewicz {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {

--- a/nemo-physical/src/function/definitions/string.rs
+++ b/nemo-physical/src/function/definitions/string.rs
@@ -114,7 +114,7 @@ fn string_vec_from_any(parameters: &[AnyDataValue]) -> Option<Vec<LangTaggedStri
 ///
 /// Returns `None` if either parameter is not a (language tagged) string or
 /// if the two language tags do not comply with Argument Compatibility Rules.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringCompare;
 impl BinaryFunction for StringCompare {
     fn evaluate(
@@ -150,7 +150,7 @@ impl BinaryFunction for StringCompare {
 /// Returns an empty plain string if no parameters are given.
 ///
 /// Returns `None` if either parameter is not a string.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringConcatenation;
 impl NaryFunction for StringConcatenation {
     fn evaluate(&self, parameters: &[AnyDataValue]) -> Option<AnyDataValue> {
@@ -184,7 +184,7 @@ impl NaryFunction for StringConcatenation {
 ///
 /// Returns `None` if either parameter is not a (language tagged) string or
 /// if the two language tags do not comply with Argument Compatibility Rules.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringContains;
 impl BinaryFunction for StringContains {
     fn evaluate(
@@ -218,7 +218,7 @@ impl BinaryFunction for StringContains {
 ///
 /// Returns `None` if either parameter is not a (language tagged) string or
 /// if the two language tags do not comply with Argument Compatibility Rules.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringStarts;
 impl BinaryFunction for StringStarts {
     fn evaluate(
@@ -263,7 +263,7 @@ impl BinaryFunction for StringStarts {
 ///
 /// Returns `None` if either parameter is not a (language tagged) string or
 /// if the two language tags do not comply with Argument Compatibility Rules.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringEnds;
 impl BinaryFunction for StringEnds {
     fn evaluate(
@@ -313,7 +313,7 @@ impl BinaryFunction for StringEnds {
 ///
 /// Returns `None` if either parameter is not a (language tagged) string or if
 /// the two language tags do not comply with Argument Compatibility Rules.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringBefore;
 impl BinaryFunction for StringBefore {
     fn evaluate(
@@ -360,7 +360,7 @@ impl BinaryFunction for StringBefore {
 ///
 /// Returns `None` if either parameter is not a (language tagged) string or if
 /// the two language tags do not comply with Argument Compatibility Rules.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringAfter;
 impl BinaryFunction for StringAfter {
     fn evaluate(
@@ -411,7 +411,7 @@ impl BinaryFunction for StringAfter {
 /// Otherwise, return a plain string.
 ///
 /// Returns `None` if the type requirements from above are not met.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringSubstring;
 impl BinaryFunction for StringSubstring {
     fn evaluate(
@@ -452,7 +452,7 @@ static REGEX_CACHE: OnceCell<Mutex<lru::LruCache<String, regex::Regex>>> = OnceC
 ///
 /// Returns `None` if either parameter is not a (language tagged) string, if the second parameter is not
 /// a regular expression or if the two language tags do not comply with Argument Compatibility Rules.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringRegex;
 impl BinaryFunction for StringRegex {
     fn evaluate(
@@ -499,7 +499,7 @@ impl BinaryFunction for StringRegex {
 ///
 /// Returns `None` if either parameter is not a (language tagged) string or
 /// if the two language tags do not comply with Argument Compatibility Rules.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringLevenshtein;
 impl BinaryFunction for StringLevenshtein {
     fn evaluate(
@@ -524,7 +524,7 @@ impl BinaryFunction for StringLevenshtein {
 /// Returns a plain string.
 ///
 /// Returns `None` if the provided argument is not a (language tagged) string
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringLength;
 impl UnaryFunction for StringLength {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -546,7 +546,7 @@ impl UnaryFunction for StringLength {
 /// Otherwise, return a plain string.
 ///
 /// Returns `None` if the provided argument is not a (language tagged) string.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringReverse;
 impl UnaryFunction for StringReverse {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -573,7 +573,7 @@ impl UnaryFunction for StringReverse {
 /// Otherwise, return a plain string.
 ///
 /// Returns `None` if the provided argument is not a (language tagged) string.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringUppercase;
 impl UnaryFunction for StringUppercase {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -602,7 +602,7 @@ impl UnaryFunction for StringUppercase {
 /// Otherwise, return a plain string.
 ///
 /// Returns `None` if the provided argument is not a (language tagged) string.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringLowercase;
 impl UnaryFunction for StringLowercase {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -630,7 +630,7 @@ impl UnaryFunction for StringLowercase {
 /// Returns a plain string.
 ///
 /// Returns `None` if the provided argument is not a (language tagged) string.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringUriEncode;
 impl UnaryFunction for StringUriEncode {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -657,7 +657,7 @@ impl UnaryFunction for StringUriEncode {
 /// Returns a plain string.
 ///
 /// Returns `None` if the provided argument is not a (language tagged) string.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringUriDecode;
 impl UnaryFunction for StringUriDecode {
     fn evaluate(&self, parameter: AnyDataValue) -> Option<AnyDataValue> {
@@ -688,7 +688,7 @@ impl UnaryFunction for StringUriDecode {
 /// Otherwise, return a plain string.
 ///
 /// Returns `None` if the type requirements from above are not met.
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, PartialEq, Eq)]
 pub struct StringSubstringLength;
 impl TernaryFunction for StringSubstringLength {
     fn evaluate(

--- a/nemo-physical/src/function/evaluation.rs
+++ b/nemo-physical/src/function/evaluation.rs
@@ -23,7 +23,7 @@ use super::{
 pub(crate) type StackReferenceIndex = usize;
 
 /// A value pushed onto the evaluation stack of [StackProgram]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum StackValue {
     /// A constant value on the stack
     Constant(AnyDataValue),
@@ -36,7 +36,7 @@ pub(crate) enum StackValue {
 }
 
 /// Operation performed in a [StackProgram]
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub(crate) enum StackOperation {
     /// Push the given value onto the stack.
     Push(StackValue),
@@ -51,7 +51,7 @@ pub(crate) enum StackOperation {
 }
 
 /// Representation of a [FunctionTree] as a stack program
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct StackProgram {
     /// Maximmum size of the stack
     size: usize,

--- a/nemo-physical/src/function/tree.rs
+++ b/nemo-physical/src/function/tree.rs
@@ -189,6 +189,42 @@ where
             None
         }
     }
+
+    /// A (mutable) iterator over the leaves of this tree.
+    pub fn leaves(&mut self) -> impl Iterator<Item = &mut FunctionTree<ReferenceType>> {
+        let mut result = Vec::new();
+        match self {
+            leaf @ FunctionTree::Leaf(_) => result.push(leaf),
+            FunctionTree::Unary(_function, tree) => result.extend(tree.leaves()),
+            FunctionTree::Binary {
+                function: _,
+                left,
+                right,
+            } => {
+                result.extend(left.leaves());
+                result.extend(right.leaves());
+            }
+            FunctionTree::Ternary {
+                function: _,
+                first,
+                second,
+                third,
+            } => {
+                result.extend(first.leaves());
+                result.extend(second.leaves());
+                result.extend(third.leaves());
+            }
+            FunctionTree::Nary {
+                function: _,
+                parameters,
+            } => {
+                for parameter in parameters {
+                    result.extend(parameter.leaves())
+                }
+            }
+        }
+        result.into_iter()
+    }
 }
 
 // Contains constructors for each type of operation

--- a/nemo-physical/src/tabular/filters.rs
+++ b/nemo-physical/src/tabular/filters.rs
@@ -7,7 +7,7 @@ use crate::function::{evaluation::StackProgram, tree::FunctionTree};
 use super::operations::OperationColumnMarker;
 
 /// A filter or transformation applied to a position
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TransformPosition {
     pub(crate) position: usize,
     pub(crate) program: StackProgram,
@@ -28,7 +28,7 @@ impl TransformPosition {
 }
 
 /// A pattern that can be used to filter and transform the tuples in a tuple buffer.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FilterTransformPattern {
     pub(crate) filter: StackProgram,
     pub(crate) transformations: Vec<TransformPosition>,


### PR DESCRIPTION
A rule like `head(?x, ?r) :- body(?x, ?y), ?z = 2 * ?y, ?r = ?z + 7` would lead to a transform pattern for position 2 that adds 7 to referenced position 2, which doesn't exist – this would panic during materialisation. Handle this by inlining away any auxiliary bindings.