### PR TITLE
Correctly handle multiple import atoms in one rule

### DIFF
--- a/nemo-physical/src/tabular/operations/incremental_import.rs
+++ b/nemo-physical/src/tabular/operations/incremental_import.rs
@@ -15,8 +15,6 @@ use crate::{
     tabular::{rowscan::RowScan, trie::Trie, triescan::PartialTrieScan},
 };
 
-use super::OperationTable;
-
 /// Database operation that triggers an import
 /// with bindings that are derived from
 /// one or more input tables
@@ -43,31 +41,13 @@ pub(crate) struct GeneratorIncrementalImport {
 impl GeneratorIncrementalImport {
     /// Create a new [GeneratorIncrementalImport].
     ///
-    /// Every marker in the output table must appear in exactly one of the input tables.
-    ///
     /// # Panics
     /// Panics if the above condition is not met.
     pub(crate) fn new(
-        output: OperationTable,
-        inputs: Vec<OperationTable>,
+        bound_positions: Vec<Vec<usize>>,
+        arity_output: usize,
         provider: Rc<Box<dyn TableProvider>>,
     ) -> Self {
-        let arity_output = output.arity();
-
-        let mut bound_positions = Vec::default();
-
-        for input in inputs {
-            let mut positions = Vec::default();
-
-            for column in input {
-                positions.push(output.position(&column).expect(
-                    "function assumes that every input column is present in the output table",
-                ));
-            }
-
-            bound_positions.push(positions);
-        }
-
         Self {
             provider,
             bound_positions,

--- a/nemo/src/execution/planning/operations/join_imports.rs
+++ b/nemo/src/execution/planning/operations/join_imports.rs
@@ -96,7 +96,12 @@ impl GeneratorJoinImports {
         let mut join_tables = vec![node_input];
         for import in &self.imports {
             let mut node_imports = import.create_plan(plan, runtime);
-            if let Some(node_new_import) = new_imports.get(import.predicate()).cloned() {
+            let import_markers = runtime
+                .translation
+                .operation_table(import.output_variables().iter());
+
+            if let Some(mut node_new_import) = new_imports.get(import.predicate()).cloned() {
+                node_new_import.set_markers(import_markers);
                 node_imports.add_subnode(node_new_import);
             }
 

--- a/nemo/src/execution/planning/operations/join_seminaive.rs
+++ b/nemo/src/execution/planning/operations/join_seminaive.rs
@@ -131,4 +131,9 @@ impl GeneratorJoinSeminaive {
     pub fn output_variables(&self) -> Vec<Variable> {
         self.order.as_ordered_list()
     }
+
+    /// Return whether this join is empty.
+    pub fn is_empty(&self) -> bool {
+        self.variants.is_empty()
+    }
 }

--- a/nemo/src/execution/planning/operations/union.rs
+++ b/nemo/src/execution/planning/operations/union.rs
@@ -71,6 +71,15 @@ impl GeneratorUnion {
         }
     }
 
+    /// Create a new [GeneratorUnion] that produces unmarked execution nodes.
+    pub fn new_unmarked(predicate: Tag, range: UnionRange) -> Self {
+        Self {
+            predicate,
+            variables: Vec::default(),
+            range,
+        }
+    }
+
     /// Create a new [Union] form a [BodyAtom].
     pub fn new_atom(atom: &BodyAtom, range: UnionRange) -> Self {
         Self::new(atom.predicate(), atom.terms().cloned().collect(), range)
@@ -123,7 +132,7 @@ impl GeneratorUnion {
 
     /// Return the variables marking the column of the node
     /// created by `create_plan`.
-    pub fn _output_variables(&self) -> Vec<Variable> {
+    pub fn output_variables(&self) -> Vec<Variable> {
         self.variables.clone()
     }
 

--- a/nemo/src/execution/planning/strategy/forward/body.rs
+++ b/nemo/src/execution/planning/strategy/forward/body.rs
@@ -65,7 +65,7 @@ impl StrategyBody {
 
             let join = GeneratorJoinCartesian::new(&order, &positive, operations, &mut negative);
             let variables_join = join.output_variables();
-            let single_factor = variables_join.len() == 1;
+            let single_factor = join.is_single_join();
 
             let import = GeneratorImport::new(variables_join, &imports);
 
@@ -141,7 +141,7 @@ impl StrategyBody {
             } => {
                 let nodes_join = join.create_plan(plan, runtime);
 
-                let merge_input = if nodes_join.len() == 1 {
+                let merge_input = if join.is_single_join() {
                     Some(nodes_join[0].clone())
                 } else {
                     None


### PR DESCRIPTION
Fixes an issue with incremental imports what caused a crash in cases where a rule contained multiple import atoms with the same binding pattern.