### PR TITLE
fix tracing computation of valid nodes

### DIFF
--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -249,7 +249,7 @@ async fn handle_tracing_node(
                 error: error.to_string(),
             })?;
 
-        let result = engine.trace_node(&node_query).await;
+        let result = engine.trace_node(&node_query).await?;
 
         let json = serde_json::to_string_pretty(&result).expect("json serialization failed");
         println!("{json}");

--- a/nemo-wasm/src/lib.rs
+++ b/nemo-wasm/src/lib.rs
@@ -375,7 +375,12 @@ impl NemoEngine {
             table_entries_for_tree_nodes_query,
         );
 
-        let response = self.engine.trace_node(&query).await;
+        let response = self
+            .engine
+            .trace_node(&query)
+            .await
+            .map_err(WasmOrInternalNemoError::Nemo)
+            .map_err(NemoError)?;
 
         let table_entries_for_tree_nodes_response = response
             .elements

--- a/nemo/src/execution/execution_engine/tracing/node_query/util.rs
+++ b/nemo/src/execution/execution_engine/tracing/node_query/util.rs
@@ -197,7 +197,13 @@ pub(super) fn valid_tables_plan(
         node_join.add_subnode(node_union);
     }
 
-    let input_variables = Vec::default();
+    let input_variables = rule
+        .positive_all()
+        .iter()
+        .flat_map(|atom| atom.terms())
+        .chain(head_variables.iter())
+        .cloned()
+        .collect::<Vec<_>>();
 
     let mut operations = rule.operations().clone();
     let mut atoms_negations = rule.negative().clone();


### PR DESCRIPTION
Fixes a bug in type 2 tracing where operations would not get applied correctly during the bottom-up phase.

Also addresses an issue where ids would be assigned inconsistently between the two tracing types (see #747).