### PR TITLE
Improve error reporting for illegal variable names

### DIFF
--- a/nemo/src/parser/ast/token.rs
+++ b/nemo/src/parser/ast/token.rs
@@ -387,7 +387,7 @@ impl<'a> Token<'a> {
         context(
             ParserContext::token(TokenKind::Name),
             recognize(pair(
-                alpha1,
+                context(ParserContext::AlphaNum, alpha1),
                 many0(alt((alphanumeric1, tag("_"), tag("%")))),
             )),
         )(input)

--- a/nemo/src/parser/context.rs
+++ b/nemo/src/parser/context.rs
@@ -169,6 +169,9 @@ pub enum ParserContext {
     /// Error
     #[assoc(name = "error")]
     Error,
+    /// A letter or a digit
+    #[assoc(name = "letter or digit")]
+    AlphaNum,
 }
 
 impl ParserContext {


### PR DESCRIPTION
Improve the reporting of illegal variable names, e.g., in fstrings (previously, this would report “expected `)`” at the opening `"`):

```
[01] Error: expected `letter or digit`
   ╭─[ /dev/shm/foo.rls:2:15 ]
   │
 2 │ foo(f"test: {?_test}") :- bar(_), ?_test = 42.
   │               │
   │               ╰─ expected `letter or digit`
───╯
```