### PR TITLE
Trace all IDB facts

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "crane": {
       "locked": {
-        "lastModified": 1776635034,
-        "narHash": "sha256-OEOJrT3ZfwbChzODfIH4GzlNTtOFuZFWPtW7jIeR8xU=",
+        "lastModified": 1779130139,
+        "narHash": "sha256-BLrtr42azquO7MdGFU5a7KiMl3YpFlTeIXqy1fT5GlQ=",
         "owner": "ipetkov",
         "repo": "crane",
-        "rev": "dc7496d8ea6e526b1254b55d09b966e94673750f",
+        "rev": "edb38893982a3338972bb4a2ec7ce7c29ba10fd9",
         "type": "github"
       },
       "original": {
@@ -5871,11 +5871,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776848421,
-        "narHash": "sha256-zUXgvn+CRkBitoJuFC24ZXWR5B39Wdwoxdzi+u7O4Ac=",
+        "lastModified": 1779107993,
+        "narHash": "sha256-CqFEJfxKjbN0VsmOKBN4mvnSo2tA1/VnsDhXx2v/L8Y=",
         "owner": "knowsys",
         "repo": "nemo-web",
-        "rev": "f45b5648b26baa35ac1b3a6234dd39bc48bbe2cb",
+        "rev": "c8c3b8f55a092d4046ea729b14a29f0b9f033b14",
         "type": "github"
       },
       "original": {
@@ -8014,11 +8014,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1776560675,
-        "narHash": "sha256-p68udKWWh7+V4ZPpcMDq0gTHWNZJnr4JPI+kHPPE40o=",
+        "lastModified": 1779102034,
+        "narHash": "sha256-vZJZjLo513IeI8hjzHFc6TDezUd4uCE2Eq4SNO3DNNg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "e07580dae39738e46609eaab8b154de2488133ce",
+        "rev": "687f05a9184cad4eaf905c48b63649e3a86f5433",
         "type": "github"
       },
       "original": {
@@ -9554,11 +9554,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1776827647,
-        "narHash": "sha256-sYixYhp5V8jCajO8TRorE4fzs7IkL4MZdfLTKgkPQBk=",
+        "lastModified": 1779160702,
+        "narHash": "sha256-frUihZLlBLdcFN95mq5QiQmxF2M16nxtmw1GH4rhZmg=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "40e6ccc06e1245a4837cbbd6bdda64e21cc67379",
+        "rev": "8cd592658d4448c57326aaa819e1c2f91086eb40",
         "type": "github"
       },
       "original": {

--- a/nemo-cli/src/cli.rs
+++ b/nemo-cli/src/cli.rs
@@ -157,6 +157,9 @@ impl OutputArgs {
 /// Cli arguments related to tracing
 #[derive(Debug, clap::Args)]
 pub(crate) struct TracingArgs {
+    /// Trace all IDB facts
+    #[arg(long = "trace-all-idb-facts", group = "trace-input")]
+    pub(crate) trace_all_idb_facts: bool,
     /// Facts for which a derivation trace should be computed;
     /// multiple facts can be separated by a semicolon, e.g. "P(a, b);Q(c)".
     #[arg(long = "trace", value_delimiter = ';', group = "trace-input")]

--- a/nemo-cli/src/main.rs
+++ b/nemo-cli/src/main.rs
@@ -18,12 +18,9 @@
 
 pub mod cli;
 pub mod error;
+pub mod tracing;
 
-use std::{
-    fs::{File, read_to_string},
-    io::Write,
-    io::stdout,
-};
+use std::{io::Write, io::stdout};
 
 use clap::Parser;
 use colored::Colorize;
@@ -35,16 +32,15 @@ use nemo::{
     datavalues::AnyDataValue,
     error::Error,
     execution::{
-        DefaultExecutionEngine, ExecutionEngine,
-        execution_parameters::ExecutionParameters,
+        DefaultExecutionEngine, ExecutionEngine, execution_parameters::ExecutionParameters,
         planning::normalization::program::NormalizedProgram,
-        tracing::{node_query::TableEntriesForTreeNodesQuery, tree_query::TreeForTableQuery},
     },
     io::{ImportManager, resource_providers::ResourceProviders},
     meta::timing::{TimedCode, TimedDisplay},
     rule_file::RuleFile,
-    rule_model::components::{ComponentBehavior, fact::Fact, tag::Tag, term::Term},
+    rule_model::components::{fact::Fact, tag::Tag, term::Term},
 };
+use tracing::handle_tracing;
 
 fn print_facts_for_table<W: Write>(
     writer: &mut W,
@@ -152,110 +148,6 @@ fn print_timing_details() {
 /// Prints detailed memory information.
 fn print_memory_details(engine: &DefaultExecutionEngine) {
     println!("\nMemory report:\n\n{}", engine.memory_usage());
-}
-
-/// Retrieve all facts that need to be traced from the cli arguments.
-fn parse_trace_facts(cli: &CliApp) -> Result<Vec<String>, Error> {
-    let mut facts = cli.tracing.facts.clone().unwrap_or_default();
-
-    if let Some(input_files) = &cli.tracing.input_file {
-        for input_file in input_files {
-            let file_content = read_to_string(input_file)?;
-            facts.extend(file_content.split(';').map(str::to_string));
-        }
-    }
-
-    Ok(facts)
-}
-
-/// Deal with tracing
-async fn handle_tracing(cli: &CliApp, engine: &mut DefaultExecutionEngine) -> Result<(), CliError> {
-    let tracing_facts = parse_trace_facts(cli)?;
-    if !tracing_facts.is_empty() {
-        log::info!("Starting tracing of {} facts...", tracing_facts.len());
-        let mut facts = Vec::<Fact>::with_capacity(tracing_facts.len());
-        for fact_string in &tracing_facts {
-            let fact = Fact::parse(fact_string).map_err(|_| CliError::TracingInvalidFact {
-                fact: fact_string.clone(),
-            })?;
-            if fact.validate().is_err() {
-                return Err(CliError::TracingInvalidFact {
-                    fact: fact_string.clone(),
-                });
-            }
-
-            facts.push(fact);
-        }
-
-        let (trace, handles) = engine.trace(facts).await?;
-
-        match &cli.tracing.output_file {
-            Some(output_file) => {
-                let filename = output_file.to_string_lossy().to_string();
-                let trace_json = trace.json(&handles);
-
-                let mut json_file = File::create(output_file)?;
-                if serde_json::to_writer(&mut json_file, &trace_json).is_err() {
-                    return Err(CliError::SerializationError { filename });
-                }
-            }
-            None => {
-                for (fact, handle) in tracing_facts.into_iter().zip(handles) {
-                    if let Some(tree) = trace.tree(handle) {
-                        println!("\n{}", tree.to_ascii_art());
-                    } else {
-                        println!("\n{fact} was not derived");
-                    }
-                }
-            }
-        }
-    }
-
-    Ok(())
-}
-
-async fn handle_tracing_tree(
-    cli: &CliApp,
-    engine: &mut DefaultExecutionEngine,
-) -> Result<(), CliError> {
-    if let Some(query_file) = &cli.tracing_tree.trace_tree_json {
-        let query_string = read_to_string(query_file)?;
-
-        let tree_query: TreeForTableQuery =
-            serde_json::from_str(&query_string).map_err(|error| {
-                CliError::TracingInvalidJsonInput {
-                    error: error.to_string(),
-                }
-            })?;
-
-        let result = engine.trace_tree(tree_query).await?;
-
-        let json = serde_json::to_string_pretty(&result).expect("json serialization failed");
-        println!("{json}");
-    }
-
-    Ok(())
-}
-
-async fn handle_tracing_node(
-    cli: &CliApp,
-    engine: &mut DefaultExecutionEngine,
-) -> Result<(), CliError> {
-    if let Some(query_file) = &cli.tracing_node.trace_node_json {
-        let query_string = read_to_string(query_file)?;
-
-        let node_query: TableEntriesForTreeNodesQuery = serde_json::from_str(&query_string)
-            .map_err(|error| CliError::TracingInvalidJsonInput {
-                error: error.to_string(),
-            })?;
-
-        let result = engine.trace_node(&node_query).await?;
-
-        let json = serde_json::to_string_pretty(&result).expect("json serialization failed");
-        println!("{json}");
-    }
-
-    Ok(())
 }
 
 async fn run(mut cli: CliApp) -> Result<(), CliError> {
@@ -369,9 +261,7 @@ async fn run(mut cli: CliApp) -> Result<(), CliError> {
         print_memory_details(&engine);
     }
 
-    handle_tracing(&cli, &mut engine).await?;
-    handle_tracing_tree(&cli, &mut engine).await?;
-    handle_tracing_node(&cli, &mut engine).await
+    handle_tracing(&cli, &mut engine).await
 }
 
 #[tokio::main(flavor = "current_thread")]

--- a/nemo-cli/src/tracing.rs
+++ b/nemo-cli/src/tracing.rs
@@ -27,6 +27,7 @@ pub(crate) fn parse_trace_facts(cli: &CliApp) -> Result<Vec<String>, Error> {
     Ok(facts)
 }
 
+/// Handle all tracing-related options specified on the command line.
 pub(crate) async fn handle_tracing(
     cli: &CliApp,
     engine: &mut DefaultExecutionEngine,
@@ -36,7 +37,7 @@ pub(crate) async fn handle_tracing(
     trace_node_query(cli, engine).await
 }
 
-/// Trace selected facts, if given on the command line
+/// Trace selected facts, if given on the command line.
 pub(crate) async fn trace_selected_facts(
     cli: &CliApp,
     engine: &mut DefaultExecutionEngine,

--- a/nemo-cli/src/tracing.rs
+++ b/nemo-cli/src/tracing.rs
@@ -1,0 +1,132 @@
+//! Code related to tracing of facts
+
+use std::fs::{File, read_to_string};
+
+use nemo::{
+    error::Error,
+    execution::{
+        DefaultExecutionEngine,
+        tracing::{node_query::TableEntriesForTreeNodesQuery, tree_query::TreeForTableQuery},
+    },
+    rule_model::components::{ComponentBehavior, fact::Fact},
+};
+
+use crate::{cli::CliApp, error::CliError};
+
+/// Retrieve all facts that need to be traced from the cli arguments.
+pub(crate) fn parse_trace_facts(cli: &CliApp) -> Result<Vec<String>, Error> {
+    let mut facts = cli.tracing.facts.clone().unwrap_or_default();
+
+    if let Some(input_files) = &cli.tracing.input_file {
+        for input_file in input_files {
+            let file_content = read_to_string(input_file)?;
+            facts.extend(file_content.split(';').map(str::to_string));
+        }
+    }
+
+    Ok(facts)
+}
+
+pub(crate) async fn handle_tracing(
+    cli: &CliApp,
+    engine: &mut DefaultExecutionEngine,
+) -> Result<(), CliError> {
+    trace_selected_facts(cli, engine).await?;
+    trace_tree_query(cli, engine).await?;
+    trace_node_query(cli, engine).await
+}
+
+/// Trace selected facts, if given on the command line
+pub(crate) async fn trace_selected_facts(
+    cli: &CliApp,
+    engine: &mut DefaultExecutionEngine,
+) -> Result<(), CliError> {
+    let tracing_facts = parse_trace_facts(cli)?;
+    if !tracing_facts.is_empty() {
+        log::info!("Starting tracing of {} facts...", tracing_facts.len());
+        let mut facts = Vec::<Fact>::with_capacity(tracing_facts.len());
+        for fact_string in &tracing_facts {
+            let fact = Fact::parse(fact_string).map_err(|_| CliError::TracingInvalidFact {
+                fact: fact_string.clone(),
+            })?;
+            if fact.validate().is_err() {
+                return Err(CliError::TracingInvalidFact {
+                    fact: fact_string.clone(),
+                });
+            }
+
+            facts.push(fact);
+        }
+
+        let (trace, handles) = engine.trace(facts).await?;
+
+        match &cli.tracing.output_file {
+            Some(output_file) => {
+                let filename = output_file.to_string_lossy().to_string();
+                let trace_json = trace.json(&handles);
+
+                let mut json_file = File::create(output_file)?;
+                if serde_json::to_writer(&mut json_file, &trace_json).is_err() {
+                    return Err(CliError::SerializationError { filename });
+                }
+            }
+            None => {
+                for (fact, handle) in tracing_facts.into_iter().zip(handles) {
+                    if let Some(tree) = trace.tree(handle) {
+                        println!("\n{}", tree.to_ascii_art());
+                    } else {
+                        println!("\n{fact} was not derived");
+                    }
+                }
+            }
+        }
+    }
+
+    Ok(())
+}
+
+/// Produce a trace for a tree query, if given on the command line.
+pub(crate) async fn trace_tree_query(
+    cli: &CliApp,
+    engine: &mut DefaultExecutionEngine,
+) -> Result<(), CliError> {
+    if let Some(query_file) = &cli.tracing_tree.trace_tree_json {
+        let query_string = read_to_string(query_file)?;
+
+        let tree_query: TreeForTableQuery =
+            serde_json::from_str(&query_string).map_err(|error| {
+                CliError::TracingInvalidJsonInput {
+                    error: error.to_string(),
+                }
+            })?;
+
+        let result = engine.trace_tree(tree_query).await?;
+
+        let json = serde_json::to_string_pretty(&result).expect("json serialization failed");
+        println!("{json}");
+    }
+
+    Ok(())
+}
+
+/// Produce a trace for a node query, if given on the command line.
+pub(crate) async fn trace_node_query(
+    cli: &CliApp,
+    engine: &mut DefaultExecutionEngine,
+) -> Result<(), CliError> {
+    if let Some(query_file) = &cli.tracing_node.trace_node_json {
+        let query_string = read_to_string(query_file)?;
+
+        let node_query: TableEntriesForTreeNodesQuery = serde_json::from_str(&query_string)
+            .map_err(|error| CliError::TracingInvalidJsonInput {
+                error: error.to_string(),
+            })?;
+
+        let result = engine.trace_node(&node_query).await?;
+
+        let json = serde_json::to_string_pretty(&result).expect("json serialization failed");
+        println!("{json}");
+    }
+
+    Ok(())
+}

--- a/nemo-cli/src/tracing.rs
+++ b/nemo-cli/src/tracing.rs
@@ -41,8 +41,36 @@ pub(crate) async fn trace_selected_facts(
     cli: &CliApp,
     engine: &mut DefaultExecutionEngine,
 ) -> Result<(), CliError> {
-    let tracing_facts = parse_trace_facts(cli)?;
-    if !tracing_facts.is_empty() {
+    let (trace, handles) = if cli.tracing.trace_all_idb_facts {
+        let predicates = engine
+            .chase_program()
+            .derived_predicates()
+            .iter()
+            .filter_map(|predicate| {
+                let count = engine
+                    .count_facts_in_memory_for_predicate(predicate)
+                    .unwrap_or_default();
+                (count > 0).then_some((predicate, count))
+            })
+            .collect::<Vec<_>>();
+        let total_facts = predicates.iter().map(|(_, count)| count).sum::<usize>();
+        log::info!(
+            "Starting tracing of {total_facts} for {} predicates",
+            predicates.len()
+        );
+
+        let predicates = predicates
+            .iter()
+            .map(|&(predicate, _)| predicate.clone())
+            .collect::<Vec<_>>();
+
+        engine.trace_predicates(&predicates).await?
+    } else {
+        let tracing_facts = parse_trace_facts(cli)?;
+        if tracing_facts.is_empty() {
+            return Ok(());
+        }
+
         log::info!("Starting tracing of {} facts...", tracing_facts.len());
         let mut facts = Vec::<Fact>::with_capacity(tracing_facts.len());
         for fact_string in &tracing_facts {
@@ -58,25 +86,26 @@ pub(crate) async fn trace_selected_facts(
             facts.push(fact);
         }
 
-        let (trace, handles) = engine.trace_facts(facts).await?;
+        engine.trace_facts(facts).await?
+    };
 
-        match &cli.tracing.output_file {
-            Some(output_file) => {
-                let filename = output_file.to_string_lossy().to_string();
-                let trace_json = trace.json(&handles);
+    match &cli.tracing.output_file {
+        Some(output_file) => {
+            let filename = output_file.to_string_lossy().to_string();
+            let trace_json = trace.json(&handles);
 
-                let mut json_file = File::create(output_file)?;
-                if serde_json::to_writer(&mut json_file, &trace_json).is_err() {
-                    return Err(CliError::SerializationError { filename });
-                }
+            let mut json_file = File::create(output_file)?;
+            if serde_json::to_writer(&mut json_file, &trace_json).is_err() {
+                return Err(CliError::SerializationError { filename });
             }
-            None => {
-                for (fact, handle) in tracing_facts.into_iter().zip(handles) {
-                    if let Some(tree) = trace.tree(handle) {
-                        println!("\n{}", tree.to_ascii_art());
-                    } else {
-                        println!("\n{fact} was not derived");
-                    }
+        }
+        None => {
+            for handle in handles {
+                if let Some(tree) = trace.tree(handle) {
+                    println!("\n{}", tree.to_ascii_art());
+                } else {
+                    let fact = trace.get_fact(handle).fact();
+                    println!("\n{fact} was not derived");
                 }
             }
         }

--- a/nemo-cli/src/tracing.rs
+++ b/nemo-cli/src/tracing.rs
@@ -58,7 +58,7 @@ pub(crate) async fn trace_selected_facts(
             facts.push(fact);
         }
 
-        let (trace, handles) = engine.trace(facts).await?;
+        let (trace, handles) = engine.trace_facts(facts).await?;
 
         match &cli.tracing.output_file {
             Some(output_file) => {

--- a/nemo-physical/src/datavalues/boolean_datavalue.rs
+++ b/nemo-physical/src/datavalues/boolean_datavalue.rs
@@ -49,12 +49,12 @@ impl DataValue for BooleanDataValue {
         if self.0 {
             format!(
                 "\"{TRUE}\"{RDF_DATATYPE_INDICATOR}<{}>",
-                &self.datatype_iri()
+                self.datatype_iri()
             )
         } else {
             format!(
                 "\"{FALSE}\"{RDF_DATATYPE_INDICATOR}<{}>",
-                &self.datatype_iri()
+                self.datatype_iri()
             )
         }
     }

--- a/nemo-physical/src/management/database/order.rs
+++ b/nemo-physical/src/management/database/order.rs
@@ -65,7 +65,7 @@ impl OrderedReferenceManager {
         self.reference_map
             .retain(|existing_id, _| *existing_id < table_id);
 
-        for (_, map) in self.storage_map.iter_mut() {
+        for map in self.storage_map.values_mut() {
             map.retain(|_, existing_id| *existing_id < storage_id);
         }
     }

--- a/nemo-physical/src/util/mapping/ordered_choice.rs
+++ b/nemo-physical/src/util/mapping/ordered_choice.rs
@@ -123,7 +123,7 @@ impl NatMapping for SortedChoice {
 
     fn chain_permutation(&self, permutation: &Permutation) -> Self {
         let mut result_map = self.map.clone();
-        for (_, value) in result_map.iter_mut() {
+        for value in result_map.values_mut() {
             *value = permutation.get(*value);
         }
 

--- a/nemo-python/src/lib.rs
+++ b/nemo-python/src/lib.rs
@@ -444,7 +444,7 @@ impl NemoEngine {
         let fact = Fact::parse(&fact_string).ok()?;
         fact.validate().ok()?;
 
-        let (trace, handles) = rt.block_on(self.engine.trace(vec![fact])).ok()?;
+        let (trace, handles) = rt.block_on(self.engine.trace_facts(vec![fact])).ok()?;
         let handle = *handles
             .first()
             .expect("Function trace always returns a handle for each input fact");

--- a/nemo/src/execution/execution_engine/tracing/simple.rs
+++ b/nemo/src/execution/execution_engine/tracing/simple.rs
@@ -30,12 +30,14 @@ use crate::{
 
 pub(crate) mod storage;
 
+const TRACING_PROGRESS_INCREMENT: usize = 500;
+
 impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
     /// Recursive part of `trace`.
     async fn trace_recursive(
         &mut self,
         trace: &mut ExecutionTrace,
-        fact: GroundAtom,
+        fact: &GroundAtom,
         program: &NormalizedProgram,
     ) -> Result<TraceFactHandle, TracingError> {
         let trace_handle = trace.register_fact(fact.clone());
@@ -148,7 +150,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                     let next_fact = GroundAtom::new(next_fact_predicate, next_fact_terms);
 
                     let next_handle =
-                        Box::pin(self.trace_recursive(trace, next_fact, program)).await?;
+                        Box::pin(self.trace_recursive(trace, &next_fact, program)).await?;
 
                     if trace.status(next_handle).is_success() {
                         subtraces.push(next_handle);
@@ -184,9 +186,9 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
         Ok(trace_handle)
     }
 
-    /// Build an `ExecutionTrace` for a list of facts.
-    /// Also returns a list containing a `TraceFactHandle` for each fact.
-    pub async fn trace(
+    /// Build an [ExecutionTrace] for a list of [fact](Fact)s.  Also
+    /// return a list containing the [TraceFactHandle] for each fact.
+    pub async fn trace_facts(
         &mut self,
         facts: Vec<Fact>,
     ) -> Result<(ExecutionTrace, Vec<TraceFactHandle>), Error> {
@@ -201,31 +203,42 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
         let program = self.program.clone();
 
-        let chase_facts: Vec<_> = facts
+        let ground_facts: Vec<_> = facts
             .into_iter()
             .filter_map(|fact| GroundAtom::normalize_fact(&fact))
             .collect();
 
+        self.trace_ground_facts(&program, &ground_facts).await
+    }
+
+    /// Build an `ExecutionTrace` for a list of [ground
+    /// facts](GroundAtom). Also return a list with the
+    /// [TraceFactHandle] for each fact.
+    pub async fn trace_ground_facts(
+        &mut self,
+        program: &NormalizedProgram,
+        ground_facts: &[GroundAtom],
+    ) -> Result<(ExecutionTrace, Vec<TraceFactHandle>), Error> {
         let mut trace = ExecutionTrace::new(self.program_handle.clone());
         let mut handles = Vec::new();
 
-        let num_chase_facts = chase_facts.len();
+        let num_ground_facts = ground_facts.len();
 
-        for (i, chase_fact) in chase_facts.into_iter().enumerate() {
-            if i > 0 && i.is_multiple_of(500) {
+        for (i, ground_fact) in ground_facts.into_iter().enumerate() {
+            if i > 0 && i.is_multiple_of(TRACING_PROGRESS_INCREMENT) {
                 log::info!(
-                    "{i}/{num_chase_facts} facts traced. ({}%)",
-                    i * 100 / num_chase_facts
+                    "{i}/{num_ground_facts} facts traced. ({}%)",
+                    i * 100 / num_ground_facts
                 );
             }
 
             handles.push(
-                self.trace_recursive(&mut trace, chase_fact, &program)
+                self.trace_recursive(&mut trace, ground_fact, &program)
                     .await?,
             );
         }
 
-        log::info!("{num_chase_facts}/{num_chase_facts} facts traced. (100%)");
+        log::info!("{num_ground_facts}/{num_ground_facts} facts traced. (100%)");
 
         Ok((trace, handles))
     }

--- a/nemo/src/execution/execution_engine/tracing/simple.rs
+++ b/nemo/src/execution/execution_engine/tracing/simple.rs
@@ -22,6 +22,7 @@ use crate::{
         components::{
             ComponentBehavior,
             fact::Fact,
+            tag::Tag,
             term::primitive::{Primitive, ground::GroundTerm, variable::Variable},
         },
         substitution::Substitution,
@@ -186,8 +187,8 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
         Ok(trace_handle)
     }
 
-    /// Build an [ExecutionTrace] for a list of [fact](Fact)s.  Also
-    /// return a list containing the [TraceFactHandle] for each fact.
+    /// Build an `ExecutionTrace` for a list of [fact](Fact)s.  Also
+    /// return a list containing the `TraceFactHandle` for each fact.
     pub async fn trace_facts(
         &mut self,
         facts: Vec<Fact>,
@@ -201,25 +202,56 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
             }
         }
 
-        let program = self.program.clone();
-
         let ground_facts: Vec<_> = facts
             .into_iter()
             .filter_map(|fact| GroundAtom::normalize_fact(&fact))
             .collect();
+        let mut trace = ExecutionTrace::new(self.program_handle.clone());
+        let handles = self.trace_ground_facts(&mut trace, &ground_facts).await?;
 
-        self.trace_ground_facts(&program, &ground_facts).await
+        Ok((trace, handles))
+    }
+
+    /// Build an `ExecutionTrace` for a list of [predicates](Tag)s.  Also
+    /// return a list containing the `TraceFactHandle` for each fact.
+    pub async fn trace_predicates(
+        &mut self,
+        predicates: impl IntoIterator<Item = &Tag>,
+    ) -> Result<(ExecutionTrace, Vec<TraceFactHandle>), Error> {
+        let mut trace = ExecutionTrace::new(self.program_handle.clone());
+        let mut handles = Vec::new();
+
+        for predicate in predicates {
+            let count = self
+                .count_facts_in_memory_for_predicate(&predicate)
+                .unwrap_or_default();
+
+            if count > 0 {
+                log::info!("Starting tracing of {count} facts for predicate {predicate}");
+
+                let ground_facts = self
+                    .predicate_rows(predicate)
+                    .await?
+                    .expect("predicate should have facts")
+                    .map(|values| {
+                        GroundAtom::new(predicate.clone(), values.into_iter().map(GroundTerm::new))
+                    })
+                    .collect::<Vec<_>>();
+                handles.append(&mut self.trace_ground_facts(&mut trace, &ground_facts).await?);
+            }
+        }
+
+        Ok((trace, handles))
     }
 
     /// Build an `ExecutionTrace` for a list of [ground
     /// facts](GroundAtom). Also return a list with the
-    /// [TraceFactHandle] for each fact.
-    pub async fn trace_ground_facts(
+    /// `TraceFactHandle` for each fact.
+    async fn trace_ground_facts(
         &mut self,
-        program: &NormalizedProgram,
+        trace: &mut ExecutionTrace,
         ground_facts: &[GroundAtom],
-    ) -> Result<(ExecutionTrace, Vec<TraceFactHandle>), Error> {
-        let mut trace = ExecutionTrace::new(self.program_handle.clone());
+    ) -> Result<Vec<TraceFactHandle>, Error> {
         let mut handles = Vec::new();
 
         let num_ground_facts = ground_facts.len();
@@ -233,13 +265,13 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
             }
 
             handles.push(
-                self.trace_recursive(&mut trace, ground_fact, &program)
+                self.trace_recursive(trace, ground_fact, &self.program.clone())
                     .await?,
             );
         }
 
         log::info!("{num_ground_facts}/{num_ground_facts} facts traced. (100%)");
 
-        Ok((trace, handles))
+        Ok(handles)
     }
 }

--- a/nemo/src/execution/execution_engine/tracing/simple.rs
+++ b/nemo/src/execution/execution_engine/tracing/simple.rs
@@ -223,7 +223,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
         for predicate in predicates {
             let count = self
-                .count_facts_in_memory_for_predicate(&predicate)
+                .count_facts_in_memory_for_predicate(predicate)
                 .unwrap_or_default();
 
             if count > 0 {
@@ -256,7 +256,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
         let num_ground_facts = ground_facts.len();
 
-        for (i, ground_fact) in ground_facts.into_iter().enumerate() {
+        for (i, ground_fact) in ground_facts.iter().enumerate() {
             if i > 0 && i.is_multiple_of(TRACING_PROGRESS_INCREMENT) {
                 log::info!(
                     "{i}/{num_ground_facts} facts traced. ({}%)",


### PR DESCRIPTION
This adds an `--trace-all-idb-facts` CLI option (mutually exclusive with `--trace` and `--trace-input-file`) that will output traces for all derived facts after reasoning.