### PR TITLE
Improve Performance of Variable Order Computation

### DIFF
--- a/nemo/src/execution/execution_engine/tracing/node_query.rs
+++ b/nemo/src/execution/execution_engine/tracing/node_query.rs
@@ -118,7 +118,6 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
             for (index, (atom, node_atom)) in rule
                 .positive_all()
-                .iter()
                 .zip(successor.children.iter())
                 .enumerate()
             {
@@ -129,7 +128,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                     manager,
                     node_atom,
                     next_address,
-                    &atom.predicate(),
+                    atom.predicate(),
                     program,
                 ))
                 .await?;
@@ -179,7 +178,6 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
             for (index, (atom, node_atom)) in rule
                 .positive_all()
-                .iter()
                 .zip(successor.children.iter())
                 .enumerate()
             {
@@ -200,7 +198,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                     manager,
                     node_atom,
                     next_address,
-                    &atom.predicate(),
+                    atom.predicate(),
                     &discarded_columns,
                     next_step,
                     program,
@@ -368,7 +366,6 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
             for (index, (atom, node_atom)) in rule
                 .positive_all()
-                .iter()
                 .zip(successor.children.iter())
                 .enumerate()
             {
@@ -604,7 +601,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                     elements,
                     child,
                     next_address,
-                    &next_predicate,
+                    next_predicate,
                 ))
                 .await?;
             }
@@ -614,10 +611,10 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
             for (index, negative_atom) in rule.negative().iter().enumerate() {
                 let mut next_address = address.clone();
-                next_address.push(rule.positive_all().len() + index);
+                next_address.push(rule.positive_all().count() + index);
 
                 let rows =
-                    if let Some(rows) = self.predicate_rows(&negative_atom.predicate()).await? {
+                    if let Some(rows) = self.predicate_rows(negative_atom.predicate()).await? {
                         rows.collect::<Vec<_>>()
                     } else {
                         Vec::default()
@@ -628,7 +625,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                 for row in rows {
                     let (entry_id, _step) = self
                         .table_manager
-                        .table_row_id(&negative_atom.predicate(), &row)
+                        .table_row_id(negative_atom.predicate(), &row)
                         .await
                         .expect("rows has been filled from tables and therefore must have an id");
 
@@ -703,5 +700,5 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 fn rule_is_simple(program: &NormalizedProgram, rule: &NormalizedRule) -> bool {
     rule.positive()
         .iter()
-        .all(|atom| program.rules_with_head_predicate(&atom.predicate()).count() <= 1)
+        .all(|atom| program.rules_with_head_predicate(atom.predicate()).count() <= 1)
 }

--- a/nemo/src/execution/execution_engine/tracing/node_query/util.rs
+++ b/nemo/src/execution/execution_engine/tracing/node_query/util.rs
@@ -53,7 +53,6 @@ pub(super) fn variable_translation(
 
     let positive_variables = rule
         .positive_all()
-        .iter()
         .flat_map(|atom| atom.terms())
         .cloned()
         .collect::<HashSet<_>>();
@@ -75,7 +74,6 @@ pub(super) fn variable_translation(
                 {
                     if !rule
                         .positive_all()
-                        .iter()
                         .flat_map(|atom| atom.terms())
                         .contains(variable)
                     {
@@ -183,7 +181,7 @@ pub(super) fn valid_tables_plan(
         node_join.add_subnode(node_query);
     }
 
-    for (body_index, body_atom) in rule.positive_all().iter().enumerate() {
+    for (body_index, body_atom) in rule.positive_all().enumerate() {
         let mut body_address = address.clone();
         body_address.push(body_index);
 
@@ -199,7 +197,6 @@ pub(super) fn valid_tables_plan(
 
     let input_variables = rule
         .positive_all()
-        .iter()
         .flat_map(|atom| atom.terms())
         .chain(head_variables.iter())
         .cloned()
@@ -487,7 +484,7 @@ where
             let node = subplan_union(
                 plan,
                 table_manager,
-                &atom.predicate(),
+                atom.predicate(),
                 0..current_step_number,
                 subtract_markers.clone(),
             );

--- a/nemo/src/execution/execution_engine/tracing/simple.rs
+++ b/nemo/src/execution/execution_engine/tracing/simple.rs
@@ -134,8 +134,8 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
 
                 let mut fully_derived = true;
                 let mut subtraces = Vec::<TraceFactHandle>::new();
-                for body_atom in rule.positive_all() {
-                    let next_fact_predicate = body_atom.predicate();
+                for body_atom in rule.positive_all_cloned() {
+                    let next_fact_predicate = body_atom.predicate_cloned();
                     let next_fact_terms = body_atom
                         .terms()
                         .map(|variable| {

--- a/nemo/src/execution/execution_engine/tracing/tree_query.rs
+++ b/nemo/src/execution/execution_engine/tracing/tree_query.rs
@@ -116,7 +116,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
             let rule = self.chase_program().rules()[rule_index].clone();
             for negative_atom in rule.negative() {
                 let rows =
-                    if let Ok(Some(rows)) = self.predicate_rows(&negative_atom.predicate()).await {
+                    if let Ok(Some(rows)) = self.predicate_rows(negative_atom.predicate()).await {
                         rows.collect::<Vec<_>>()
                     } else {
                         Vec::default()
@@ -126,7 +126,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                 for row in rows {
                     let (entry_id, _step) = self
                         .table_manager
-                        .table_row_id(&negative_atom.predicate(), &row)
+                        .table_row_id(negative_atom.predicate(), &row)
                         .await
                         .expect("row should be contained somewhere");
 
@@ -167,8 +167,8 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
             .zip(grounding.iter().cloned())
             .collect();
 
-        for (body_index, body_atom) in rule.positive_all().iter().enumerate() {
-            let next_fact_predicate = body_atom.predicate();
+        for (body_index, body_atom) in rule.positive_all().enumerate() {
+            let next_fact_predicate = body_atom.predicate().clone();
             let next_fact_terms = body_atom
                 .terms()
                 .map(|variable| {
@@ -343,7 +343,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                     Vec::new();
                     self.chase_program().rules()[rule_index]
                         .positive_all()
-                        .len()
+                        .count()
                 ];
 
                 for groundings in results {
@@ -392,7 +392,7 @@ impl<Strategy: RuleSelectionStrategy> ExecutionEngine<Strategy> {
                         Vec::new();
                         self.chase_program().rules()[rule_index]
                             .positive_all()
-                            .len()
+                            .count()
                     ];
 
                     for grounding in groundings {

--- a/nemo/src/execution/planning/analysis/variable_order.rs
+++ b/nemo/src/execution/planning/analysis/variable_order.rs
@@ -167,8 +167,6 @@ impl std::fmt::Debug for VariableOrder {
     }
 }
 
-// The variants not listed in `ITERATION_ORDERS` are unused, but kept so that computing
-// several variable orders per rule can be reactivated by extending that list.
 #[allow(dead_code)]
 #[derive(Debug, Clone, Copy)]
 enum IterationOrder {
@@ -179,13 +177,8 @@ enum IterationOrder {
 
 /// The [IterationOrder]s used to generate variable orders.
 ///
-/// Every entry produces one variable order per rule, and the distinct results are
-/// collected. Only one order per rule is ever used, however, so computing more than one
-/// is wasted work; [IterationOrder::Backward] is the variant that was effectively
-/// selected back when all three were computed.
-///
-/// Listing several entries again is all that is needed to reactivate the comparison
-/// of multiple orders.
+/// Every entry produces one variable order per rule, 
+/// and the distinct results are collected.
 const ITERATION_ORDERS: &[IterationOrder] = &[IterationOrder::Backward];
 
 impl IterationOrder {

--- a/nemo/src/execution/planning/analysis/variable_order.rs
+++ b/nemo/src/execution/planning/analysis/variable_order.rs
@@ -167,12 +167,26 @@ impl std::fmt::Debug for VariableOrder {
     }
 }
 
-#[derive(Debug)]
+// The variants not listed in `ITERATION_ORDERS` are unused, but kept so that computing
+// several variable orders per rule can be reactivated by extending that list.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy)]
 enum IterationOrder {
     Forward,
     Backward,
     InsideOut,
 }
+
+/// The [IterationOrder]s used to generate variable orders.
+///
+/// Every entry produces one variable order per rule, and the distinct results are
+/// collected. Only one order per rule is ever used, however, so computing more than one
+/// is wasted work; [IterationOrder::Backward] is the variant that was effectively
+/// selected back when all three were computed.
+///
+/// Listing several entries again is all that is needed to reactivate the comparison
+/// of multiple orders.
+const ITERATION_ORDERS: &[IterationOrder] = &[IterationOrder::Backward];
 
 impl IterationOrder {
     fn get_permutator(&self, len: usize) -> Permutator {
@@ -561,12 +575,6 @@ pub(crate) fn build_preferable_variable_orders(
     program: &NormalizedProgram,
     initial_column_orders: Option<HashMap<Tag, HashSet<ColumnOrder>>>,
 ) -> BuilderResultVariants {
-    let iteration_orders = [
-        IterationOrder::Forward,
-        IterationOrder::Backward,
-        IterationOrder::InsideOut,
-    ];
-
     let initial_column_orders = initial_column_orders.unwrap_or_else(|| {
         let mut result: HashMap<Tag, HashSet<Permutation>> = Default::default();
         for fact in program.facts().iter() {
@@ -584,7 +592,7 @@ pub(crate) fn build_preferable_variable_orders(
     let mut all_variable_orders = vec![Vec::<VariableOrder>::new(); program.rules().len()];
     let mut all_column_orders = Vec::new();
 
-    for iteration_order in iteration_orders {
+    for &iteration_order in ITERATION_ORDERS {
         let BuilderResult {
             variable_orders,
             column_orders,
@@ -841,18 +849,11 @@ mod test {
         }
 
         let rule_vars = &var_lists[0];
-        let rule_var_orders: Vec<VariableOrder> = vec![
-            VariableOrder::from_vec(vec![
-                rule_vars[1].clone(),
-                rule_vars[0].clone(),
-                rule_vars[2].clone(),
-            ]),
-            VariableOrder::from_vec(vec![
-                rule_vars[1].clone(),
-                rule_vars[2].clone(),
-                rule_vars[0].clone(),
-            ]),
-        ];
+        let rule_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
+            rule_vars[1].clone(),
+            rule_vars[2].clone(),
+            rule_vars[0].clone(),
+        ])];
 
         assert_eq!(
             vec![rule_var_orders],
@@ -873,18 +874,11 @@ mod test {
         }
 
         let rule_vars = &var_lists[0];
-        let rule_var_orders: Vec<VariableOrder> = vec![
-            VariableOrder::from_vec(vec![
-                rule_vars[1].clone(),
-                rule_vars[0].clone(),
-                rule_vars[2].clone(),
-            ]),
-            VariableOrder::from_vec(vec![
-                rule_vars[1].clone(),
-                rule_vars[2].clone(),
-                rule_vars[0].clone(),
-            ]),
-        ];
+        let rule_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
+            rule_vars[1].clone(),
+            rule_vars[2].clone(),
+            rule_vars[0].clone(),
+        ])];
 
         assert_eq!(
             vec![rule_var_orders],
@@ -913,18 +907,11 @@ mod test {
             rule_1_vars[2].clone(),
         ])];
         let rule_2_vars = &var_lists[1];
-        let rule_2_var_orders: Vec<VariableOrder> = vec![
-            VariableOrder::from_vec(vec![
-                rule_2_vars[1].clone(),
-                rule_2_vars[0].clone(),
-                rule_2_vars[2].clone(),
-            ]),
-            VariableOrder::from_vec(vec![
-                rule_2_vars[1].clone(),
-                rule_2_vars[2].clone(),
-                rule_2_vars[0].clone(),
-            ]),
-        ];
+        let rule_2_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
+            rule_2_vars[1].clone(),
+            rule_2_vars[2].clone(),
+            rule_2_vars[0].clone(),
+        ])];
 
         assert_eq!(
             vec![rule_1_var_orders, rule_2_var_orders],
@@ -1077,20 +1064,12 @@ mod test {
             rule_3_vars[3].clone(),
         ])];
         let rule_4_vars = &var_lists[3];
-        let rule_4_var_orders: Vec<VariableOrder> = vec![
-            VariableOrder::from_vec(vec![
-                rule_4_vars[0].clone(),
-                rule_4_vars[1].clone(),
-                rule_4_vars[2].clone(),
-                rule_4_vars[3].clone(),
-            ]),
-            VariableOrder::from_vec(vec![
-                rule_4_vars[0].clone(),
-                rule_4_vars[2].clone(),
-                rule_4_vars[1].clone(),
-                rule_4_vars[3].clone(),
-            ]),
-        ];
+        let rule_4_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
+            rule_4_vars[0].clone(),
+            rule_4_vars[2].clone(),
+            rule_4_vars[1].clone(),
+            rule_4_vars[3].clone(),
+        ])];
         let rule_5_vars = &var_lists[4];
         let rule_5_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
             rule_5_vars[0].clone(),
@@ -1367,20 +1346,12 @@ mod test {
             rule_3_vars[3].clone(),
         ])];
         let rule_4_vars = &var_lists[3];
-        let rule_4_var_orders: Vec<VariableOrder> = vec![
-            VariableOrder::from_vec(vec![
-                rule_4_vars[0].clone(),
-                rule_4_vars[1].clone(),
-                rule_4_vars[2].clone(),
-                rule_4_vars[3].clone(),
-            ]),
-            VariableOrder::from_vec(vec![
-                rule_4_vars[0].clone(),
-                rule_4_vars[2].clone(),
-                rule_4_vars[1].clone(),
-                rule_4_vars[3].clone(),
-            ]),
-        ];
+        let rule_4_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
+            rule_4_vars[0].clone(),
+            rule_4_vars[2].clone(),
+            rule_4_vars[1].clone(),
+            rule_4_vars[3].clone(),
+        ])];
         let rule_5_vars = &var_lists[4];
         let rule_5_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
             rule_5_vars[1].clone(),
@@ -1396,20 +1367,12 @@ mod test {
             rule_6_vars[0].clone(),
         ])];
         let rule_7_vars = &var_lists[6];
-        let rule_7_var_orders: Vec<VariableOrder> = vec![
-            VariableOrder::from_vec(vec![
-                rule_7_vars[1].clone(),
-                rule_7_vars[0].clone(),
-                rule_7_vars[2].clone(),
-                rule_7_vars[3].clone(),
-            ]),
-            VariableOrder::from_vec(vec![
-                rule_7_vars[1].clone(),
-                rule_7_vars[0].clone(),
-                rule_7_vars[3].clone(),
-                rule_7_vars[2].clone(),
-            ]),
-        ];
+        let rule_7_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
+            rule_7_vars[1].clone(),
+            rule_7_vars[0].clone(),
+            rule_7_vars[3].clone(),
+            rule_7_vars[2].clone(),
+        ])];
         let rule_8_vars = &var_lists[7];
         let rule_8_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
             rule_8_vars[0].clone(),
@@ -1424,28 +1387,16 @@ mod test {
             rule_9_vars[0].clone(),
         ])];
         let rule_10_vars = &var_lists[9];
-        let rule_10_var_orders: Vec<VariableOrder> = vec![
-            VariableOrder::from_vec(vec![
-                rule_10_vars[0].clone(),
-                rule_10_vars[1].clone(),
-                rule_10_vars[4].clone(),
-                rule_10_vars[2].clone(),
-                rule_10_vars[3].clone(),
-                rule_10_vars[5].clone(),
-                rule_10_vars[6].clone(),
-                rule_10_vars[7].clone(),
-            ]),
-            VariableOrder::from_vec(vec![
-                rule_10_vars[0].clone(),
-                rule_10_vars[4].clone(),
-                rule_10_vars[1].clone(),
-                rule_10_vars[3].clone(),
-                rule_10_vars[2].clone(),
-                rule_10_vars[5].clone(),
-                rule_10_vars[6].clone(),
-                rule_10_vars[7].clone(),
-            ]),
-        ];
+        let rule_10_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
+            rule_10_vars[0].clone(),
+            rule_10_vars[4].clone(),
+            rule_10_vars[1].clone(),
+            rule_10_vars[3].clone(),
+            rule_10_vars[2].clone(),
+            rule_10_vars[5].clone(),
+            rule_10_vars[6].clone(),
+            rule_10_vars[7].clone(),
+        ])];
         let rule_11_vars = &var_lists[10];
         let rule_11_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
             rule_11_vars[0].clone(),
@@ -1453,10 +1404,10 @@ mod test {
             rule_11_vars[2].clone(),
         ])];
         let rule_12_vars = &var_lists[11];
-        let rule_12_var_orders: Vec<VariableOrder> = vec![
-            VariableOrder::from_vec(vec![rule_12_vars[0].clone(), rule_12_vars[1].clone()]),
-            VariableOrder::from_vec(vec![rule_12_vars[1].clone(), rule_12_vars[0].clone()]),
-        ];
+        let rule_12_var_orders: Vec<VariableOrder> = vec![VariableOrder::from_vec(vec![
+            rule_12_vars[1].clone(),
+            rule_12_vars[0].clone(),
+        ])];
 
         assert_eq!(
             vec![

--- a/nemo/src/execution/planning/analysis/variable_order.rs
+++ b/nemo/src/execution/planning/analysis/variable_order.rs
@@ -2,7 +2,7 @@
 // https://github.com/phil-hanisch/rulewerk/blob/lftj/rulewerk-lftj/src/main/java/org/semanticweb/rulewerk/lftj/implementation/Heuristic.java
 // NOTE: some functions are slightly modified but the overall idea is reflected
 
-use std::collections::{BTreeMap, HashMap, HashSet};
+use std::collections::{BinaryHeap, HashMap, HashSet, hash_map::Entry};
 
 use nemo_physical::{
     management::execution_plan::ColumnOrder, permutator::Permutator,
@@ -11,136 +11,133 @@ use nemo_physical::{
 
 use crate::{
     execution::planning::normalization::{
-        atom::body::BodyAtom, program::NormalizedProgram, rule::NormalizedRule,
+        atom::body::BodyAtomRef, program::NormalizedProgram, rule::NormalizedRule,
     },
     rule_model::components::{tag::Tag, term::primitive::variable::Variable},
 };
 
-/// Represents an ordering of variables as [HashMap].
-#[repr(transparent)]
-#[derive(Clone, Default, PartialEq, Eq)]
-pub struct VariableOrder(HashMap<Variable, usize>);
+/// Represents an ordering of variables
+#[derive(Clone, Default)]
+pub struct VariableOrder {
+    /// Variables in the order prescribed by this object
+    variables: Vec<Variable>,
+    /// Maps each variable in `variables` to its position
+    positions: HashMap<Variable, usize>,
+}
+
+impl PartialEq for VariableOrder {
+    fn eq(&self, other: &Self) -> bool {
+        self.variables == other.variables
+    }
+}
+
+impl Eq for VariableOrder {}
 
 impl VariableOrder {
     /// Create new [VariableOrder].
     pub fn new<Iterator: IntoIterator<Item = Variable>>(variables: Iterator) -> Self {
-        let mut order = HashMap::new();
-        for (index, variable) in variables.into_iter().enumerate() {
-            order.insert(variable, index);
+        let mut result = Self::default();
+        for variable in variables {
+            result.push(variable);
         }
-        Self(order)
+
+        result
     }
 
     /// Insert new variable in the last position.
+    ///
+    /// Does nothing if the variable is already contained in this order.
     pub fn push(&mut self, variable: Variable) {
-        let max_index = self.0.values().max();
-        self.0.insert(variable, max_index.map_or(0, |i| i + 1));
+        if let Entry::Vacant(entry) = self.positions.entry(variable.clone()) {
+            entry.insert(self.variables.len());
+            self.variables.push(variable);
+        }
+    }
+
+    /// Remove the variable in the last position.
+    fn pop(&mut self) {
+        if let Some(variable) = self.variables.pop() {
+            self.positions.remove(&variable);
+        }
+    }
+
+    /// Call `function` with this order temporarily extended by `variable`,
+    /// restoring the original order afterwards.
+    fn with_extended<Result>(
+        &mut self,
+        variable: &Variable,
+        function: impl FnOnce(&Self) -> Result,
+    ) -> Result {
+        if self.contains(variable) {
+            return function(self);
+        }
+
+        self.push(variable.clone());
+        let result = function(self);
+        self.pop();
+
+        result
     }
 
     /// Insert a new variable at a certain position.
     pub fn _push_position(&mut self, variable: Variable, position: usize) {
-        for current_position in &mut self.0.values_mut() {
-            if *current_position >= position {
-                *current_position += 1;
-            }
-        }
+        debug_assert!(!self.positions.contains_key(&variable));
 
-        let insert_result = self.0.insert(variable, position);
-        debug_assert!(insert_result.is_none());
+        self.variables.insert(position, variable);
+        self.positions.clear();
+        self.positions
+            .extend(self.variables.iter().cloned().zip(0..));
     }
 
     /// Get position of a variable.
     pub fn get(&self, variable: &Variable) -> Option<&usize> {
-        self.0.get(variable)
+        self.positions.get(variable)
     }
 
     /// Check if variable is part of the [VariableOrder].
     pub fn contains(&self, variable: &Variable) -> bool {
-        self.0.contains_key(variable)
+        self.positions.contains_key(variable)
     }
 
     /// Returns a [VariableOrder] which is restricted to the given variables (but preserve their order)
     pub fn restrict_to(&self, variables: &HashSet<Variable>) -> Self {
-        let mut variable_vector = Vec::<Variable>::with_capacity(variables.len());
-        for variable in variables {
-            if self.0.contains_key(variable) {
-                variable_vector.push(variable.clone());
-            }
-        }
-
-        variable_vector.sort_by(|a, b| {
-            self.get(a)
-                .unwrap()
-                .partial_cmp(self.get(b).unwrap())
-                .unwrap()
-        });
-
-        let mut result = HashMap::<Variable, usize>::new();
-
-        for (index, variable) in variable_vector.into_iter().enumerate() {
-            result.insert(variable, index);
-        }
-
-        Self(result)
+        Self::new(
+            self.variables
+                .iter()
+                .filter(|variable| variables.contains(*variable))
+                .cloned(),
+        )
     }
 
     /// Returns the number of entries.
     pub fn len(&self) -> usize {
-        self.0.len()
+        self.variables.len()
     }
 
     /// Returns whether it contains any entry.
     pub fn _is_empty(&self) -> bool {
-        self.0.is_empty()
+        self.variables.is_empty()
     }
 
     /// Return an iterator over all mapped variables.
-    pub fn iter(&self) -> impl Iterator<Item = &Variable> {
-        let mut vars: Vec<&Variable> = self.0.keys().collect();
-        vars.sort_by_key(|var| {
-            self.0
-                .get(var)
-                .expect("we are iterating over existing keys")
-        });
-        vars.into_iter()
+    pub fn iter(&self) -> impl Iterator<Item = &Variable> + Clone {
+        self.variables.iter()
     }
 
     /// Return a vector which puts the variables in the order prescribed by `self`.
     pub fn as_ordered_list(&self) -> Vec<Variable> {
-        let mut variables: Vec<Variable> = self.iter().cloned().collect();
-        variables.sort_by(|a, b| self.get(a).unwrap().cmp(self.get(b).unwrap()));
-
-        variables
+        self.variables.clone()
     }
 
     /// Return [String] with the contents of this object for debugging.
     pub(crate) fn _debug(&self) -> String {
-        let mut variable_vector = Vec::<Variable>::new();
-        variable_vector.resize_with(self.0.len(), || Variable::universal("PLACEHOLDER"));
+        let names = self
+            .variables
+            .iter()
+            .map(|variable| variable.name().unwrap_or("_"))
+            .collect::<Vec<_>>();
 
-        for (variable, index) in &self.0 {
-            if *index >= variable_vector.len() {
-                return String::from("TODO: Fix this function");
-            }
-
-            variable_vector[*index] = variable.clone();
-        }
-
-        let mut result = String::new();
-
-        result += "[";
-        for (index, variable) in variable_vector.iter().enumerate() {
-            let identifier = variable.name().unwrap_or("_");
-
-            result += identifier;
-
-            if index < variable_vector.len() - 1 {
-                result += ", ";
-            }
-        }
-        result += "]";
-
-        result
+        format!("[{}]", names.join(", "))
     }
 
     /// Extend this order with the variables provided by the iterator.
@@ -193,27 +190,17 @@ impl IterationOrder {
     }
 }
 
-fn column_order_for(atom: &BodyAtom, var_order: &VariableOrder) -> ColumnOrder {
-    let mut partial_col_order: Vec<usize> = var_order
-        .iter()
-        .flat_map(|var| {
-            atom.terms()
-                .enumerate()
-                .filter(move |(_, lit_var)| *lit_var == var)
-                .map(|(i, _)| i)
-        })
-        .collect();
+/// Compute the [ColumnOrder] for `atom` induced by `var_order`:
+/// columns whose variable occurs in `var_order` come first, in that order,
+/// followed by the remaining columns in their original order.
+fn column_order_for(atom: BodyAtomRef<'_>, var_order: &VariableOrder) -> ColumnOrder {
+    let terms = atom.term_slice();
+    let mut column_order: Vec<usize> = (0..terms.len()).collect();
 
-    let mut remaining_vars: Vec<usize> = atom
-        .terms()
-        .enumerate()
-        .map(|(i, _)| i)
-        .filter(|i| !partial_col_order.contains(i))
-        .collect();
+    column_order
+        .sort_by_key(|&column| var_order.get(&terms[column]).copied().unwrap_or(usize::MAX));
 
-    partial_col_order.append(&mut remaining_vars);
-
-    ColumnOrder::from_vector(partial_col_order)
+    ColumnOrder::from_vector(column_order)
 }
 
 trait RuleVariableList {
@@ -225,7 +212,7 @@ trait RuleVariableList {
 
     fn filter_tries<P: FnMut(&Tag) -> bool>(
         self,
-        partial_var_order: &VariableOrder,
+        partial_var_order: &mut VariableOrder,
         rule: &NormalizedRule,
         required_trie_column_orders: &HashMap<Tag, HashSet<ColumnOrder>>,
         predicate_filter: P,
@@ -241,12 +228,10 @@ impl RuleVariableList for Vec<Variable> {
         let result: Vec<Variable> = self
             .iter()
             .filter(|var| {
-                rule.positive_all().iter().any(|atom| {
-                    let predicate_vars: Vec<Variable> = atom.terms().cloned().collect();
-
-                    predicate_vars.iter().any(|pred_var| pred_var == *var)
-                        && predicate_vars
-                            .iter()
+                rule.positive_all().any(|atom| {
+                    atom.terms().any(|pred_var| pred_var == *var)
+                        && atom
+                            .terms()
                             .any(|pred_var| partial_var_order.contains(pred_var))
                 })
             })
@@ -258,7 +243,7 @@ impl RuleVariableList for Vec<Variable> {
 
     fn filter_tries<P: FnMut(&Tag) -> bool>(
         self,
-        partial_var_order: &VariableOrder,
+        partial_var_order: &mut VariableOrder,
         rule: &NormalizedRule,
         required_trie_column_orders: &HashMap<Tag, HashSet<ColumnOrder>>,
         mut predicate_filter: P,
@@ -266,28 +251,24 @@ impl RuleVariableList for Vec<Variable> {
         let ratios: Vec<(usize, usize)> = self
             .iter()
             .map(|var| {
-                let mut extended_var_order: VariableOrder = partial_var_order.clone();
-                extended_var_order.push(var.clone());
+                partial_var_order.with_extended(var, |extended_var_order| {
+                    let atoms = rule
+                        .positive_all()
+                        .filter(|atom| predicate_filter(atom.predicate()))
+                        .filter(|atom| atom.terms().any(|atom_var| atom_var == var));
 
-                let atoms = rule
-                    .positive_all()
-                    .into_iter()
-                    .filter(|atom| predicate_filter(&atom.predicate()))
-                    .filter(|atom| atom.terms().any(|atom_var| atom_var == var));
+                    atoms.fold((0, 0), |acc, atom| {
+                        let fitting_column_order_exists: bool = required_trie_column_orders
+                            .get(atom.predicate())
+                            .map(|set| set.contains(&column_order_for(atom, extended_var_order)))
+                            .unwrap_or(false);
 
-                let (atoms_requiring_new_orders, total_atoms) = atoms.fold((0, 0), |acc, atom| {
-                    let fitting_column_order_exists: bool = required_trie_column_orders
-                        .get(&atom.predicate())
-                        .map(|set| set.contains(&column_order_for(&atom, &extended_var_order)))
-                        .unwrap_or(false);
+                        let new_col_order_required = !fitting_column_order_exists;
 
-                    let new_col_order_required = !fitting_column_order_exists;
-
-                    (acc.0 + usize::from(new_col_order_required), acc.1 + 1)
-                    // bool is coverted to 1 for true and 0 for false
-                });
-
-                (atoms_requiring_new_orders, total_atoms)
+                        (acc.0 + usize::from(new_col_order_required), acc.1 + 1)
+                        // bool is coverted to 1 for true and 0 for false
+                    })
+                })
             })
             .collect();
 
@@ -319,6 +300,16 @@ struct VariableOrderBuilder<'a> {
     iteration_order_within_rule: IterationOrder,
     required_trie_column_orders: HashMap<Tag, HashSet<ColumnOrder>>, // maps predicates to sets of column orders
     idb_preds: HashSet<Tag>,
+    /// Maps each predicate to the indices of the rules containing it in their positive body,
+    /// listing a rule once per occurrence of that predicate
+    predicate_to_rules: HashMap<Tag, Vec<usize>>,
+    /// Predicates that have at least one entry in `required_trie_column_orders`
+    active_predicates: HashSet<Tag>,
+    /// For each rule, the number of idb and edb predicates in its body
+    /// for which a trie is already available
+    rule_counts: Vec<(usize, usize)>,
+    /// Rules whose entry in `rule_counts` changed since it was last read
+    dirty_rules: Vec<usize>,
 }
 
 struct BuilderResult {
@@ -334,11 +325,44 @@ impl VariableOrderBuilder<'_> {
         iteration_order_within_rule: IterationOrder,
         initial_column_orders: HashMap<Tag, HashSet<ColumnOrder>>,
     ) -> BuilderResult {
+        // Predicates that already have at least one column order available
+        let active_predicates: HashSet<Tag> = initial_column_orders
+            .iter()
+            .filter(|(_, orders)| !orders.is_empty())
+            .map(|(predicate, _)| predicate.clone())
+            .collect();
+
+        // Maps a predicate to the indices of the rules containing it in their positive body.
+        // A rule is listed once per occurrence, since `rule_counts` counts occurrences.
+        let mut predicate_to_rules = HashMap::<Tag, Vec<usize>>::new();
+        let mut rule_counts = Vec::with_capacity(program.rules().len());
+
+        for (rule_index, rule) in program.rules().iter().enumerate() {
+            let mut counts = (0, 0);
+
+            for atom in rule.positive_all() {
+                predicate_to_rules
+                    .entry(atom.predicate().clone())
+                    .or_default()
+                    .push(rule_index);
+
+                if active_predicates.contains(atom.predicate()) {
+                    increment_counts(&mut counts, program.derived_predicates(), atom.predicate());
+                }
+            }
+
+            rule_counts.push(counts);
+        }
+
         let mut builder = VariableOrderBuilder {
             program,
             iteration_order_within_rule,
             required_trie_column_orders: initial_column_orders,
             idb_preds: program.derived_predicates().clone(),
+            predicate_to_rules,
+            active_predicates,
+            rule_counts,
+            dirty_rules: Vec::new(),
         };
 
         let variable_orders = builder.generate_variable_orders();
@@ -350,63 +374,65 @@ impl VariableOrderBuilder<'_> {
         }
     }
 
-    fn get_already_present_idb_edb_count_for_rule_in_tries(
-        &self,
-        rule: &NormalizedRule,
-    ) -> (usize, usize) {
-        let preds_with_tries = rule.positive_all().into_iter().filter_map(|atom| {
-            let pred = atom.predicate();
-            self.required_trie_column_orders
-                .get(&pred)
-                .is_some_and(|orders| !orders.is_empty())
-                .then_some(pred)
-        });
+    /// Record that `predicate` now has at least one column order available.
+    fn activate_predicate(&mut self, predicate: &Tag) {
+        if !self.active_predicates.insert(predicate.clone()) {
+            return;
+        }
 
-        let (idb_count, edb_count) = preds_with_tries.fold((0, 0), |(idb, edb), pred| {
-            if self.idb_preds.contains(&pred) {
-                (idb + 1, edb)
-            } else {
-                (idb, edb + 1)
-            }
-        });
+        let Some(rule_indices) = self.predicate_to_rules.get(predicate) else {
+            return;
+        };
 
-        (idb_count, edb_count)
+        for &rule_index in rule_indices {
+            increment_counts(
+                &mut self.rule_counts[rule_index],
+                &self.idb_preds,
+                predicate,
+            );
+            self.dirty_rules.push(rule_index);
+        }
     }
 
     fn generate_variable_orders(&mut self) -> Vec<VariableOrder> {
-        // NOTE: We use a BTreeMap to determinise the iteration order for easier debugging; this should not be performance critical
-        let mut remaining_rules: BTreeMap<usize, &NormalizedRule> =
-            self.program.rules().iter().enumerate().collect();
+        let program = self.program;
 
-        let mut result: Vec<(usize, VariableOrder)> =
-            Vec::with_capacity(self.program.rules().len());
-
-        while !remaining_rules.is_empty() {
-            let (next_index, next_rule) = remaining_rules
-                .iter()
-                .max_by(|(_, rule_a), (_, rule_b)| {
-                    let (idb_count_a, edb_count_a) =
-                        self.get_already_present_idb_edb_count_for_rule_in_tries(rule_a);
-                    let (idb_count_b, edb_count_b) =
-                        self.get_already_present_idb_edb_count_for_rule_in_tries(rule_b);
-
-                    if idb_count_a != idb_count_b {
-                        idb_count_a.cmp(&idb_count_b)
-                    } else {
-                        edb_count_a.cmp(&edb_count_b)
-                    }
-                })
-                .expect("the remaining rules are never empty here");
-
-            let next_index = *next_index;
-            let var_order = self.generate_variable_order_for_rule(next_rule);
-
-            remaining_rules.remove(&next_index);
-            result.push((next_index, var_order));
+        // Rules are processed in order of how many of their body predicates already
+        // have tries available, preferring idb over edb predicates.
+        //
+        // Since `rule_counts` only ever grows, a rule whose counts changed can simply be
+        // pushed again; outdated entries are recognized and skipped when they are popped.
+        let mut queue = BinaryHeap::with_capacity(program.rules().len());
+        for (rule_index, &(idb_count, edb_count)) in self.rule_counts.iter().enumerate() {
+            queue.push((idb_count, edb_count, rule_index));
         }
 
-        result.sort_by_key(|(i, _)| *i);
-        result.into_iter().map(|(_, ord)| ord).collect()
+        let mut result = vec![None; program.rules().len()];
+
+        while let Some((idb_count, edb_count, rule_index)) = queue.pop() {
+            // Outdated entries are left behind whenever a rule is pushed again with higher counts
+            if result[rule_index].is_some()
+                || self.rule_counts[rule_index] != (idb_count, edb_count)
+            {
+                continue;
+            }
+
+            let variable_order =
+                self.generate_variable_order_for_rule(&program.rules()[rule_index]);
+            result[rule_index] = Some(variable_order);
+
+            for index in self.dirty_rules.drain(..) {
+                if result[index].is_none() {
+                    let (idb_count, edb_count) = self.rule_counts[index];
+                    queue.push((idb_count, edb_count, index));
+                }
+            }
+        }
+
+        result
+            .into_iter()
+            .map(|order| order.expect("every rule is pushed initially and re-pushed when its counts change, so it gets processed"))
+            .collect()
     }
 
     fn generate_variable_order_for_rule(&mut self, rule: &NormalizedRule) -> VariableOrder {
@@ -414,7 +440,6 @@ impl VariableOrderBuilder<'_> {
         let mut remaining_vars = {
             let remaining_vars_unpermutated: Vec<Variable> = rule
                 .positive_all()
-                .iter()
                 .flat_map(|lit| lit.terms())
                 .fold(vec![], |mut acc, var| {
                     if !acc.contains(var) {
@@ -438,7 +463,7 @@ impl VariableOrderBuilder<'_> {
                     .filter_cartesian_product(&variable_order, rule);
 
                 let after_trie_idb = after_cart.filter_tries(
-                    &variable_order,
+                    &mut variable_order,
                     rule,
                     &self.required_trie_column_orders,
                     |pred| self.idb_preds.contains(pred),
@@ -446,7 +471,7 @@ impl VariableOrderBuilder<'_> {
 
                 after_trie_idb
                     .filter_tries(
-                        &variable_order,
+                        &mut variable_order,
                         rule,
                         &self.required_trie_column_orders,
                         |pred| !self.idb_preds.contains(pred),
@@ -458,7 +483,7 @@ impl VariableOrderBuilder<'_> {
 
             variable_order.push(next_var.clone());
             remaining_vars.retain(|var| var != &next_var);
-            self.update_trie_column_orders(&variable_order, HashSet::from([next_var]), rule);
+            self.update_trie_column_orders(&variable_order, &next_var, rule);
         }
 
         variable_order
@@ -467,29 +492,47 @@ impl VariableOrderBuilder<'_> {
     fn update_trie_column_orders(
         &mut self,
         variable_order: &VariableOrder,
-        must_contain: HashSet<Variable>,
+        must_contain: &Variable,
         rule: &NormalizedRule,
     ) {
-        let atoms = rule.positive_all().into_iter().filter(|atom| {
-            let vars: Vec<Variable> = atom.terms().cloned().collect();
-            must_contain.iter().all(|var| vars.contains(var))
-                && vars.iter().all(|var| variable_order.contains(var))
+        let atoms = rule.positive_all().filter(|atom| {
+            atom.terms().any(|var| var == must_contain)
+                && atom.terms().all(|var| variable_order.contains(var))
         });
 
+        let mut activated = Vec::new();
+
         for atom in atoms {
-            let column_ord: ColumnOrder = column_order_for(&atom, variable_order);
+            let column_ord: ColumnOrder = column_order_for(atom, variable_order);
 
             let set = self
                 .required_trie_column_orders
-                .entry(atom.predicate())
+                .entry(atom.predicate().clone())
                 .or_default();
 
             set.insert(column_ord);
+
+            if !self.active_predicates.contains(atom.predicate()) {
+                activated.push(atom.predicate().clone());
+            }
+        }
+
+        for predicate in activated {
+            self.activate_predicate(&predicate);
         }
     }
 
     fn get_column_orders(self) -> HashMap<Tag, HashSet<ColumnOrder>> {
         self.required_trie_column_orders
+    }
+}
+
+/// Add one to the idb or the edb count, depending on whether `predicate` is derived.
+fn increment_counts(counts: &mut (usize, usize), idb_preds: &HashSet<Tag>, predicate: &Tag) {
+    if idb_preds.contains(predicate) {
+        counts.0 += 1;
+    } else {
+        counts.1 += 1;
     }
 }
 
@@ -596,7 +639,7 @@ mod test {
 
     impl VariableOrder {
         fn from_vec(vec: Vec<Variable>) -> Self {
-            Self(vec.into_iter().enumerate().map(|(i, v)| (v, i)).collect())
+            Self::new(vec)
         }
     }
 
@@ -761,12 +804,12 @@ mod test {
     {
         let (rule, vars) = get_test_rule_with_vars_where_predicates_are_different();
         let y = vars[1].clone();
-        let empty_ord = VariableOrder::default();
+        let mut empty_ord = VariableOrder::default();
         let empty_trie_cache: HashMap<Tag, HashSet<ColumnOrder>> = HashMap::new();
 
         let expected = vec![y];
 
-        let filtered_vars = vars.filter_tries(&empty_ord, &rule, &empty_trie_cache, |_| true);
+        let filtered_vars = vars.filter_tries(&mut empty_ord, &rule, &empty_trie_cache, |_| true);
 
         assert_eq!(expected, filtered_vars);
     }
@@ -775,12 +818,12 @@ mod test {
     fn filter_tries_where_rule_predicates_are_the_same_with_empty_var_order_and_empty_trie_cache() {
         let (rule, vars) = get_test_rule_with_vars_where_predicates_are_the_same();
         let y = vars[1].clone();
-        let empty_ord = VariableOrder::default();
+        let mut empty_ord = VariableOrder::default();
         let empty_trie_cache: HashMap<Tag, HashSet<ColumnOrder>> = HashMap::new();
 
         let expected = vec![y];
 
-        let filtered_vars = vars.filter_tries(&empty_ord, &rule, &empty_trie_cache, |_| true);
+        let filtered_vars = vars.filter_tries(&mut empty_ord, &rule, &empty_trie_cache, |_| true);
 
         assert_eq!(expected, filtered_vars);
     }

--- a/nemo/src/execution/planning/analysis/variable_order.rs
+++ b/nemo/src/execution/planning/analysis/variable_order.rs
@@ -177,7 +177,7 @@ enum IterationOrder {
 
 /// The [IterationOrder]s used to generate variable orders.
 ///
-/// Every entry produces one variable order per rule, 
+/// Every entry produces one variable order per rule,
 /// and the distinct results are collected.
 const ITERATION_ORDERS: &[IterationOrder] = &[IterationOrder::Backward];
 

--- a/nemo/src/execution/planning/normalization/atom/body.rs
+++ b/nemo/src/execution/planning/normalization/atom/body.rs
@@ -57,8 +57,79 @@ impl BodyAtom {
     }
 
     /// Return the predicate of this atom.
-    pub fn predicate(&self) -> Tag {
+    pub fn predicate(&self) -> &Tag {
+        &self.predicate
+    }
+
+    /// Return a (cloned) predicate of this atom.
+    pub fn predicate_cloned(&self) -> Tag {
         self.predicate.clone()
+    }
+
+    /// Return a borrowed view of this atom.
+    pub fn as_ref(&self) -> BodyAtomRef<'_> {
+        BodyAtomRef::new(&self.predicate, &self.terms)
+    }
+}
+
+/// A borrowed view of an atom occurring in the body of a rule.
+///
+/// This allows treating [BodyAtom]s and
+/// [ImportAtom][super::import::ImportAtom]s uniformly
+/// without having to clone them.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct BodyAtomRef<'a> {
+    /// Predicate name of this atom
+    predicate: &'a Tag,
+    /// Terms contained in this atom
+    terms: &'a [Variable],
+}
+
+impl Display for BodyAtomRef<'_> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let terms = DisplaySeperatedList::display(
+            self.terms(),
+            &format!("{} ", syntax::SEQUENCE_SEPARATOR),
+        );
+        let predicate = self.predicate();
+
+        f.write_str(&format!(
+            "{predicate}{}{terms}{}",
+            syntax::expression::atom::OPEN,
+            syntax::expression::atom::CLOSE
+        ))
+    }
+}
+
+impl<'a> BodyAtomRef<'a> {
+    /// Construct a new [BodyAtomRef].
+    pub fn new(predicate: &'a Tag, terms: &'a [Variable]) -> Self {
+        Self { predicate, terms }
+    }
+
+    /// Return an iterator over all terms contained in this atom.
+    pub fn terms(self) -> impl Iterator<Item = &'a Variable> {
+        self.terms.iter()
+    }
+
+    /// Return a slice containing all terms of this atom.
+    pub fn term_slice(self) -> &'a [Variable] {
+        self.terms
+    }
+
+    /// Return the arity of this atom.
+    pub fn arity(self) -> usize {
+        self.terms.len()
+    }
+
+    /// Return the predicate of this atom.
+    pub fn predicate(self) -> &'a Tag {
+        self.predicate
+    }
+
+    /// Clone this view into an owned [BodyAtom].
+    pub fn to_owned(self) -> BodyAtom {
+        BodyAtom::new(self.predicate.clone(), self.terms.iter().cloned())
     }
 }
 

--- a/nemo/src/execution/planning/normalization/atom/import.rs
+++ b/nemo/src/execution/planning/normalization/atom/import.rs
@@ -3,7 +3,7 @@
 use std::fmt::Display;
 
 use crate::{
-    execution::planning::normalization::import::ImportInstruction,
+    execution::planning::normalization::{atom::body::BodyAtomRef, import::ImportInstruction},
     io::formats::Import,
     rule_model::components::{tag::Tag, term::primitive::variable::Variable},
     syntax,
@@ -47,8 +47,18 @@ impl ImportAtom {
     }
 
     /// Return the predicate.
-    pub fn predicate(&self) -> Tag {
+    pub fn predicate(&self) -> &Tag {
         self.import.predicate()
+    }
+
+    /// Return a (cloned) predicate.
+    pub fn predicate_cloned(&self) -> Tag {
+        self.import.predicate_cloned()
+    }
+
+    /// Return a borrowed view of this atom as a body atom.
+    pub fn as_body_atom(&self) -> BodyAtomRef<'_> {
+        BodyAtomRef::new(self.import.predicate(), &self.variables)
     }
 
     /// Return the arity of this atom.

--- a/nemo/src/execution/planning/normalization/import.rs
+++ b/nemo/src/execution/planning/normalization/import.rs
@@ -29,7 +29,12 @@ impl ImportInstruction {
     }
 
     /// Return the predicate.
-    pub fn predicate(&self) -> Tag {
+    pub fn predicate(&self) -> &Tag {
+        &self.predicate
+    }
+
+    /// Return a (cloned) predicate.
+    pub fn predicate_cloned(&self) -> Tag {
         self.predicate.clone()
     }
 

--- a/nemo/src/execution/planning/normalization/program.rs
+++ b/nemo/src/execution/planning/normalization/program.rs
@@ -91,7 +91,7 @@ impl NormalizedProgram {
         }
 
         for body in rule.positive() {
-            self.add_body_predicate_rule(body.predicate(), rule_index);
+            self.add_body_predicate_rule(body.predicate_cloned(), rule_index);
         }
 
         for head in rule.head() {
@@ -283,7 +283,10 @@ impl NormalizedProgram {
             let arity = result.predicate_arities.get(import.predicate()).cloned();
             let normalized_import = ImportInstruction::normalize_import(import, arity);
 
-            result.add_predicate_arity(normalized_import.predicate(), normalized_import.arity());
+            result.add_predicate_arity(
+                normalized_import.predicate_cloned(),
+                normalized_import.arity(),
+            );
             result.imports.push(normalized_import);
         }
 

--- a/nemo/src/execution/planning/normalization/rule.rs
+++ b/nemo/src/execution/planning/normalization/rule.rs
@@ -20,7 +20,11 @@ use crate::{
         analysis::variable_order::VariableOrder,
         normalization::{
             aggregate::Aggregation,
-            atom::{body::BodyAtom, head::HeadAtom, import::ImportAtom},
+            atom::{
+                body::{BodyAtom, BodyAtomRef},
+                head::HeadAtom,
+                import::ImportAtom,
+            },
             generator::VariableGenerator,
             operation::Operation,
         },
@@ -142,18 +146,20 @@ impl NormalizedRule {
         &self.negative_imports
     }
 
-    /// Return a list of all positive atoms, including import atoms
-    pub fn positive_all(&self) -> Vec<BodyAtom> {
-        let mut positive = self.positive.clone();
+    /// Return an iterator over all positive atoms, including import atoms.
+    ///
+    /// This borrows from the rule and hence performs no allocation;
+    /// use [NormalizedRule::positive_all_cloned] if owned atoms are required.
+    pub fn positive_all(&self) -> impl Iterator<Item = BodyAtomRef<'_>> + Clone {
+        self.positive
+            .iter()
+            .map(BodyAtom::as_ref)
+            .chain(self.positive_imports.iter().map(ImportAtom::as_body_atom))
+    }
 
-        positive.extend(self.positive_imports.iter().map(|atom| {
-            BodyAtom::new(
-                atom.predicate(),
-                atom.variables().cloned().collect::<Vec<_>>(),
-            )
-        }));
-
-        positive
+    /// Return a (cloned) list of all positive atoms, including import atoms.
+    pub fn positive_all_cloned(&self) -> Vec<BodyAtom> {
+        self.positive_all().map(|atom| atom.to_owned()).collect()
     }
 
     /// Return the list of operations in this rule.
@@ -233,7 +239,7 @@ impl NormalizedRule {
             let head_predicate = head_atom.predicate();
 
             for positive_atom in &self.positive {
-                if positive_atom.predicate() == head_predicate {
+                if *positive_atom.predicate() == head_predicate {
                     return true;
                 }
             }
@@ -317,11 +323,11 @@ impl NormalizedRule {
         let positive = self
             .positive
             .iter()
-            .map(|atom| (atom.predicate(), atom.arity()));
+            .map(|atom| (atom.predicate_cloned(), atom.arity()));
         let import = self
             .positive_imports
             .iter()
-            .map(|atom| (atom.predicate(), atom.arity()));
+            .map(|atom| (atom.predicate_cloned(), atom.arity()));
 
         positive.chain(import)
     }
@@ -331,11 +337,11 @@ impl NormalizedRule {
         let negative = self
             .negative
             .iter()
-            .map(|atom| (atom.predicate(), atom.arity()));
+            .map(|atom| (atom.predicate_cloned(), atom.arity()));
         let import = self
             .negative_imports
             .iter()
-            .map(|atom| (atom.predicate(), atom.arity()));
+            .map(|atom| (atom.predicate_cloned(), atom.arity()));
 
         negative.chain(import)
     }
@@ -366,19 +372,19 @@ impl NormalizedRule {
         let positive = self
             .positive
             .iter()
-            .map(|atom| (atom.predicate(), atom.arity()));
+            .map(|atom| (atom.predicate_cloned(), atom.arity()));
         let negative = self
             .negative
             .iter()
-            .map(|atom| (atom.predicate(), atom.arity()));
+            .map(|atom| (atom.predicate_cloned(), atom.arity()));
         let positive_import = self
             .positive_imports
             .iter()
-            .map(|atom| (atom.predicate(), atom.arity()));
+            .map(|atom| (atom.predicate_cloned(), atom.arity()));
         let negative_import = self
             .negative_imports
             .iter()
-            .map(|atom| (atom.predicate(), atom.arity()));
+            .map(|atom| (atom.predicate_cloned(), atom.arity()));
 
         head.chain(positive)
             .chain(negative)

--- a/nemo/src/execution/planning/operations/import.rs
+++ b/nemo/src/execution/planning/operations/import.rs
@@ -319,7 +319,7 @@ impl GeneratorImport {
         for atom in positive_import_atoms.iter().chain(negative_import_atoms) {
             let binding_patterns = BindingPattern::new(&input_variables, atom);
 
-            let mut product_pattern = ProductBinding::new(atom.predicate(), atom.arity());
+            let mut product_pattern = ProductBinding::new(atom.predicate_cloned(), atom.arity());
 
             for (pattern, binding, origin) in binding_patterns {
                 let binding_index = bindings.add(binding, origin);
@@ -334,11 +334,11 @@ impl GeneratorImport {
             let (import_index, _) = imports.insert_full(product_pattern);
 
             predicates
-                .entry(atom.predicate())
+                .entry(atom.predicate_cloned())
                 .or_default()
                 .push(import_index);
 
-            handlers.insert(atom.predicate(), atom.handler());
+            handlers.insert(atom.predicate_cloned(), atom.handler());
         }
 
         Self {

--- a/nemo/src/execution/planning/operations/join_imports_general.rs
+++ b/nemo/src/execution/planning/operations/join_imports_general.rs
@@ -68,7 +68,11 @@ impl GeneratorJoinImportsGeneral {
         let imports = import_atoms
             .into_iter()
             .map(|atom| {
-                GeneratorUnion::new(atom.predicate(), atom.variables_cloned(), UnionRange::All)
+                GeneratorUnion::new(
+                    atom.predicate_cloned(),
+                    atom.variables_cloned(),
+                    UnionRange::All,
+                )
             })
             .collect::<Vec<_>>();
 
@@ -76,8 +80,11 @@ impl GeneratorJoinImportsGeneral {
         let mut negative_filters = Vec::default();
 
         for atom in negative_import_atoms.into_iter() {
-            let union =
-                GeneratorUnion::new(atom.predicate(), atom.variables_cloned(), UnionRange::All);
+            let union = GeneratorUnion::new(
+                atom.predicate_cloned(),
+                atom.variables_cloned(),
+                UnionRange::All,
+            );
 
             let filter = GeneratorFilter::new(atom.variables_cloned(), operations);
 

--- a/nemo/src/execution/planning/operations/join_imports_simple.rs
+++ b/nemo/src/execution/planning/operations/join_imports_simple.rs
@@ -65,7 +65,11 @@ impl GeneratorJoinImportsSimple {
         let imports = import_atoms
             .into_iter()
             .map(|atom| {
-                GeneratorUnion::new(atom.predicate(), atom.variables_cloned(), UnionRange::All)
+                GeneratorUnion::new(
+                    atom.predicate_cloned(),
+                    atom.variables_cloned(),
+                    UnionRange::All,
+                )
             })
             .collect::<Vec<_>>();
 
@@ -73,8 +77,11 @@ impl GeneratorJoinImportsSimple {
         let mut negative_filters = Vec::default();
 
         for atom in negative_import_atoms.into_iter() {
-            let union =
-                GeneratorUnion::new(atom.predicate(), atom.variables_cloned(), UnionRange::All);
+            let union = GeneratorUnion::new(
+                atom.predicate_cloned(),
+                atom.variables_cloned(),
+                UnionRange::All,
+            );
 
             let filter = GeneratorFilter::new(atom.variables_cloned(), operations);
 

--- a/nemo/src/execution/planning/operations/union.rs
+++ b/nemo/src/execution/planning/operations/union.rs
@@ -82,7 +82,11 @@ impl GeneratorUnion {
 
     /// Create a new [Union] form a [BodyAtom].
     pub fn new_atom(atom: &BodyAtom, range: UnionRange) -> Self {
-        Self::new(atom.predicate(), atom.terms().cloned().collect(), range)
+        Self::new(
+            atom.predicate_cloned(),
+            atom.terms().cloned().collect(),
+            range,
+        )
     }
 
     /// Append this operation to the plan

--- a/nemo/src/execution/planning/strategy/tracing.rs
+++ b/nemo/src/execution/planning/strategy/tracing.rs
@@ -41,7 +41,7 @@ pub struct StrategyTracing {
 impl StrategyTracing {
     /// Creata a new [StrategyTracing].
     pub fn new(rule: &NormalizedRule, grounding: HashMap<Variable, AnyDataValue>) -> Self {
-        let positive = rule.positive_all().clone();
+        let positive = rule.positive_all_cloned();
         let ranges = vec![UnionRange::Old; positive.len()];
         let mut negative = rule.negative().clone();
         let mut operations = rule.operations().clone();


### PR DESCRIPTION
After the dependency graph computation, the variable order computation had the highest impact on large rule sets. This PR improves the performance by reducing memory allocations and rewriting the algorithm.